### PR TITLE
Support pixel privacy review automation

### DIFF
--- a/.github/actions/privacy-review/action.yml
+++ b/.github/actions/privacy-review/action.yml
@@ -15,17 +15,6 @@ inputs:
     github_pat:
         required: true
 
-outputs:
-    triage_task_id:
-        description: 'GID of the Privacy Triage Asana task created by this action.'
-        value: ${{ steps.create-review-task.outputs.taskId }}
-    triage_task_permalink:
-        description: 'Permalink URL of the Privacy Triage Asana task created by this action.'
-        value: https://app.asana.com/0/69071770703008/${{ steps.create-review-task.outputs.taskId }}
-    original_task_id:
-        description: 'GID of the original product task referenced in the PR description (matched via the trigger-phrase regex), or empty if none found.'
-        value: ${{ steps.find-asana-task-id.outputs.asanaTaskId }}
-
 runs:
     using: 'composite'
     steps:

--- a/.github/actions/privacy-review/action.yml
+++ b/.github/actions/privacy-review/action.yml
@@ -15,6 +15,17 @@ inputs:
     github_pat:
         required: true
 
+outputs:
+    triage_task_id:
+        description: "GID of the Privacy Triage Asana task created by this action."
+        value: ${{ steps.create-review-task.outputs.taskId }}
+    triage_task_permalink:
+        description: "Permalink URL of the Privacy Triage Asana task created by this action."
+        value: https://app.asana.com/0/69071770703008/${{ steps.create-review-task.outputs.taskId }}
+    original_task_id:
+        description: "GID of the original product task referenced in the PR description (matched via the trigger-phrase regex), or empty if none found."
+        value: ${{ steps.find-asana-task-id.outputs.asanaTaskId }}
+
 runs:
     using: 'composite'
     steps:

--- a/.github/actions/privacy-review/action.yml
+++ b/.github/actions/privacy-review/action.yml
@@ -17,13 +17,13 @@ inputs:
 
 outputs:
     triage_task_id:
-        description: "GID of the Privacy Triage Asana task created by this action."
+        description: 'GID of the Privacy Triage Asana task created by this action.'
         value: ${{ steps.create-review-task.outputs.taskId }}
     triage_task_permalink:
-        description: "Permalink URL of the Privacy Triage Asana task created by this action."
+        description: 'Permalink URL of the Privacy Triage Asana task created by this action.'
         value: https://app.asana.com/0/69071770703008/${{ steps.create-review-task.outputs.taskId }}
     original_task_id:
-        description: "GID of the original product task referenced in the PR description (matched via the trigger-phrase regex), or empty if none found."
+        description: 'GID of the original product task referenced in the PR description (matched via the trigger-phrase regex), or empty if none found.'
         value: ${{ steps.find-asana-task-id.outputs.asanaTaskId }}
 
 runs:
@@ -92,3 +92,28 @@ runs:
               asana-task-comment-is-html: true
               asana-task-comment-pinned: false
               action: 'post-comment-asana-task'
+
+        # Requirements on the github_pat:
+        #   - actions: write on duckduckgo/privacy-review-automation
+        # E2E-TEST REF: pinned to the in-flight classifier branch with the
+        # privacy_triage_task_id input + dual-link Step 5. Revert to 'main'
+        # before merging this PR.
+        - name: Dispatch AI Privacy Review classifier
+          if: ${{ steps.create-review-task.outputs.taskId != '' }}
+          uses: actions/github-script@v7
+          env:
+              PR_URL: ${{ github.event.pull_request.html_url }}
+              TRIAGE_TASK_ID: ${{ steps.create-review-task.outputs.taskId }}
+          with:
+              github-token: ${{ inputs.github_pat }}
+              script: |
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner: 'duckduckgo',
+                    repo: 'privacy-review-automation',
+                    workflow_id: 'privacy-review-classifier.lock.yml',
+                    ref: 'la/triage-id-link',
+                    inputs: {
+                      pr_url: process.env.PR_URL,
+                      privacy_triage_task_id: process.env.TRIAGE_TASK_ID,
+                    },
+                  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@duckduckgo/native-github-asana-sync",
-    "version": "1.3.0",
+    "version": "2.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@duckduckgo/native-github-asana-sync",
-            "version": "1.3.0",
+            "version": "2.4.0",
             "license": "ISC",
             "dependencies": {
                 "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duckduckgo/native-github-asana-sync",
-    "version": "1.3.0",
+    "version": "2.4.0",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1205243787707480/task/1214512208674130?focus=true

The composite action runs create-asana-task, which sets a `taskId` output on its inner step. Callers (per-repo privacy-review.yml workflows) had no way to read this — composite actions don't propagate inner step outputs unless declared. Expose them now so callers can chain follow-up automation like dispatching the AI Privacy Review classifier in duckduckgo/privacy-review-automation.

- triage_task_id: GID of the Privacy Triage task this action just created
- triage_task_permalink: built from the hardcoded project + the GID
- original_task_id: GID matched from the PR description by find-asana-task-id

No behavior change inside the action itself; outputs only.

After merging, cut a new tag (eg. v2.4) so per-repo workflows can pin to the version that exposes these outputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new cross-repo `workflow_dispatch` call that depends on `github_pat` permissions and a non-`main` workflow ref, which could trigger unintended automation if misconfigured.
> 
> **Overview**
> After creating the Asana privacy triage task, the composite action now **dispatches** the `privacy-review-classifier.lock.yml` workflow in `duckduckgo/privacy-review-automation`, passing `pr_url` and the created `privacy_triage_task_id`.
> 
> Also bumps this package/action version from `1.3.0` to `2.4.0` in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bd8076694254134dfbc42a7f45ab7d99aef312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->