### PR TITLE
update workflow ref to main

### DIFF
--- a/.github/actions/privacy-review/action.yml
+++ b/.github/actions/privacy-review/action.yml
@@ -76,7 +76,7 @@ runs:
               asana-pat: ${{ inputs.asana_pat }}
               asana-task-id: ${{ steps.create-review-task.outputs.taskId }}
               asana-task-comment: |
-                  <body><a data-asana-gid="${{ steps.get-author-asana-id.outputs.asanaUserId }}"/>, this triage task has been created for <a href="${{ github.event.pull_request.html_url }}/changes?file-filters[]=.json&file-filters[]=.json5">your PR.</a> 
+                  <body><a data-asana-gid="${{ steps.get-author-asana-id.outputs.asanaUserId }}"/>, this triage task has been created for <a href="${{ github.event.pull_request.html_url }}/changes?file-filters[]=.json&file-filters[]=.json5">your PR.</a>
                   Please review the task description, set the Objective and add any context that could help speed up the review process! </body>
               asana-task-comment-is-html: true
               asana-task-comment-pinned: false
@@ -84,9 +84,6 @@ runs:
 
         # Requirements on the github_pat:
         #   - actions: write on duckduckgo/privacy-review-automation
-        # E2E-TEST REF: pinned to the in-flight classifier branch with the
-        # privacy_triage_task_id input + dual-link Step 5. Revert to 'main'
-        # before merging this PR.
         - name: Dispatch AI Privacy Review classifier
           if: ${{ steps.create-review-task.outputs.taskId != '' }}
           uses: actions/github-script@v7
@@ -100,7 +97,7 @@ runs:
                     owner: 'duckduckgo',
                     repo: 'privacy-review-automation',
                     workflow_id: 'privacy-review-classifier.lock.yml',
-                    ref: 'la/triage-id-link',
+                    ref: 'main',
                     inputs: {
                       pr_url: process.env.PR_URL,
                       privacy_triage_task_id: process.env.TRIAGE_TASK_ID,


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1205243787707480/task/1215113750466052?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI wiring only; switches workflow ref after feature landed, with no application or security logic changes.
> 
> **Overview**
> Updates the **Privacy Review** composite action so the AI classifier workflow dispatch targets **`main`** on `duckduckgo/privacy-review-automation` instead of the temporary branch `la/triage-id-link`.
> 
> Removes the in-repo comment that documented that E2E pinning. The dispatch still passes `pr_url` and `privacy_triage_task_id` unchanged. There is also a trivial whitespace trim in the Asana HTML comment body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba1f049cb6f87cdc44e7647700434c5a70d36c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->