### PR TITLE
Add a set-asana-custom-fields-from-diff action

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This action integrates asana with github.
 - `send-mattermost-message` to send a message to a channel in Mattermost
 - `get-asana-task-permalink` to get the permalink for a given Asana Task ID
 - `mark-asana-task-complete` to mark an Asana task as complete or incomplete
+- `add-asana-tags-from-diff` to add Asana tags to the PR's linked task(s) based on the files changed in the PR
 
 ### Create Asana task from Github Issue
 
@@ -619,6 +620,84 @@ jobs:
                   asana-task-id: ${{ github.event.inputs.task_id }}
                   is-complete: ${{ github.event.inputs.complete }}
                   action: 'mark-asana-task-complete'
+```
+
+### Add Asana tags based on the PR diff
+
+Looks for Asana task(s) linked in the PR description and adds Asana tags to them based on which files the Pull Request changed. The mapping from file paths to tag GIDs is provided inline via the `tag-map` input, so no extra Asana API calls are needed to resolve tag names — you supply tag GIDs directly.
+
+### `asana-pat`
+
+**Required** Asana public access token
+
+### `github-pat`
+
+**Required** Github public access token
+
+### `github-org`
+
+**Required** Github organisation that owns the repository
+
+### `github-repository`
+
+**Required** Github repository name
+
+### `github-pr`
+
+**Required** Github Pull Request number
+
+### `trigger-phrase`
+
+**Optional** Prefix before the task i.e ASANA TASK: https://app.asana.com/1/2/3/. If not provided, any Asana URL in the text will be matched.
+
+### `tag-map`
+
+**Required** JSON string mapping file-path glob patterns to Asana tag GIDs.
+
+- A changed file is matched against each pattern using glob syntax: `*` matches within a single path segment, `**` matches across segments, and `?` matches a single non-`/` character. Exact paths also work.
+- A file may match multiple patterns, in which case all matching tags are added.
+- The special key `"*"` is a fallback tag applied to any changed file that did not match any other pattern.
+- All matching tag GIDs across all changed files are de-duplicated and applied to every linked task.
+
+#### How timing works
+
+Steps within a single workflow job run sequentially in the order listed, so placing this step before a `notify-pr-merged` step in the same job guarantees tags are applied before the task is completed. Ordering is only non-deterministic if the tag step and the complete step live in separate workflows triggered by the same event (they would run in parallel). Note that completing an Asana task does not remove its tags, so tags can also be added to an already-completed task.
+
+#### Example Usage
+
+```yaml
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    asana-on-merge:
+        if: github.event.pull_request.merged
+        runs-on: ubuntu-latest
+        steps:
+            - name: Tag linked Asana tasks based on the diff
+              uses: duckduckgo/native-github-asana-sync@v1.1
+              with:
+                  action: 'add-asana-tags-from-diff'
+                  asana-pat: ${{ secrets.asana_pat }}
+                  github-pat: ${{ secrets.github_pat }}
+                  github-org: ${{ github.repository_owner }}
+                  github-repository: ${{ github.event.repository.name }}
+                  github-pr: ${{ github.event.pull_request.number }}
+                  trigger-phrase: 'Task/Issue URL:'
+                  tag-map: >-
+                      {
+                        "config/feature-flags.json": "1201111111111111",
+                        "*": "1202222222222222"
+                      }
+
+            - name: Complete linked Asana tasks
+              uses: duckduckgo/native-github-asana-sync@v1.1
+              with:
+                  action: 'notify-pr-merged'
+                  asana-pat: ${{ secrets.asana_pat }}
+                  trigger-phrase: 'Task/Issue URL:'
+                  is-complete: true
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -624,9 +624,7 @@ jobs:
 
 ### Set Asana custom fields based on the PR diff
 
-Looks for Asana task(s) linked in the PR description and sets custom field values on them based on which files the Pull Request changed. The mapping from file paths to custom field values is provided inline via the `custom-field-map` input, so no extra Asana API calls are needed to resolve names — you supply field GIDs (and, for enum fields, option GIDs) directly.
-
-This is typically run as a step immediately before `notify-pr-merged` in the same job, so a required custom field is guaranteed to be set before the task is completed (avoiding Asana's "field not set" reminder on closed tasks).
+Looks for Asana task(s) linked in the PR description and sets custom field values on them based on which files the Pull Request changed.
 
 ### `asana-pat`
 
@@ -662,10 +660,6 @@ This is typically run as a step immediately before `notify-pr-merged` in the sam
 - The special key `"*"` is a fallback that only fills in fields that no specific pattern set. Keep a fallback if you want every linked task to always have the field set.
 - The resolved field values are merged and applied to every linked task in a single update.
 
-#### How timing works
-
-Steps within a single workflow job run sequentially in the order listed, so placing this step before a `notify-pr-merged` step in the same job guarantees the field is set before the task is completed. Ordering is only non-deterministic if the two steps live in separate workflows triggered by the same event (they would run in parallel). If setting the field fails, that step fails and — by GitHub's default behaviour — the subsequent completion step is skipped, so a task is not closed without its field set.
-
 #### Example Usage
 
 ```yaml
@@ -688,12 +682,11 @@ jobs:
                   github-repository: ${{ github.event.repository.name }}
                   github-pr: ${{ github.event.pull_request.number }}
                   trigger-phrase: 'Task/Issue URL:'
-                  # field GID 1201111111111111 -> option A when feature-flags.json
-                  # changed, option B for any other change
                   custom-field-map: >-
                       {
-                        "config/feature-flags.json": { "1201111111111111": "1209999999999991" },
-                        "*": { "1201111111111111": "1209999999999992" }
+                        "features/unprotected-temporary.json": { "1201111111111111": "1209999999999991" },
+                        "feature/content-blocking.json": { "1201111111111111": "1209999999999992" },
+                        "*": { "1201111111111111": "1209999999999993" }
                       }
 
             - name: Complete linked Asana tasks

--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ Looks for Asana task(s) linked in the PR description and sets custom field value
 
 **Required** JSON string mapping file-path glob patterns to an Asana `custom_fields` hash (field GID -> value).
 
-- A changed file is matched against each pattern using glob syntax: `*` matches within a single path segment, `**` matches across segments, and `?` matches a single non-`/` character. Exact paths also work.
+- Each pattern is matched against changed file paths by simple string matching: an exact path, a trailing `*` for a prefix match (e.g. `features/*` matches any file under `features/`), a leading `*` for a suffix match (e.g. `*.json` matches any file ending in `.json`), or both for a contains match (e.g. `*content-blocking*`).
 - For enum (dropdown) fields the value is the enum option's GID; for text fields it is a string; for number fields a number.
 - Because a custom field holds a single value, specific patterns are applied in **declaration order** and the first entry to set a given field GID wins (so list more specific rules first).
 - The special key `"*"` is a fallback that only fills in fields that no specific pattern set. Keep a fallback if you want every linked task to always have the field set.

--- a/README.md
+++ b/README.md
@@ -652,12 +652,12 @@ Looks for Asana task(s) linked in the PR description and sets custom field value
 
 ### `custom-field-map`
 
-**Required** JSON string mapping file-path glob patterns to an Asana `custom_fields` hash (field GID -> value).
+**Required** JSON string mapping file-path patterns to an Asana `custom_fields` hash (field GID -> value).
 
-- Each pattern is matched against changed file paths by simple string matching: an exact path, a trailing `*` for a prefix match (e.g. `features/*` matches any file under `features/`), a leading `*` for a suffix match (e.g. `*.json` matches any file ending in `.json`), or both for a contains match (e.g. `*content-blocking*`).
-- For enum (dropdown) fields the value is the enum option's GID; for text fields it is a string; for number fields a number.
-- Because a custom field holds a single value, specific patterns are applied in **declaration order** and the first entry to set a given field GID wins (so list more specific rules first).
-- The special key `"*"` is a fallback that only fills in fields that no specific pattern set. Keep a fallback if you want every linked task to always have the field set.
+- Matches on changed file paths: an exact path, a trailing `*` for a prefix match (e.g., `features/*`), a leading `*` for a suffix match (e.g., `*.json`), or both for a substring match.
+- For enum Asana fields the value is the option's GID; for text fields a string; for number fields a number.
+- Because a custom field holds a single value, patterns are applied in **declaration order** and the first entry to set a given field GID wins (so list more specific rules first).
+- Mapping is applied in order, so list more specific rules first. The `"*"` fallback can be used if you want every linked task to always have the field set.
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -658,7 +658,6 @@ Looks for Asana task(s) linked in the PR description and sets custom field value
 - For enum (dropdown) fields the value is the enum option's GID; for text fields it is a string; for number fields a number.
 - Because a custom field holds a single value, specific patterns are applied in **declaration order** and the first entry to set a given field GID wins (so list more specific rules first).
 - The special key `"*"` is a fallback that only fills in fields that no specific pattern set. Keep a fallback if you want every linked task to always have the field set.
-- The resolved field values are merged and applied to every linked task in a single update.
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This action integrates asana with github.
 - `send-mattermost-message` to send a message to a channel in Mattermost
 - `get-asana-task-permalink` to get the permalink for a given Asana Task ID
 - `mark-asana-task-complete` to mark an Asana task as complete or incomplete
-- `add-asana-tags-from-diff` to add Asana tags to the PR's linked task(s) based on the files changed in the PR
+- `set-asana-custom-fields-from-diff` to set Asana custom field values on the PR's linked task(s) based on the files changed in the PR
 
 ### Create Asana task from Github Issue
 
@@ -622,9 +622,11 @@ jobs:
                   action: 'mark-asana-task-complete'
 ```
 
-### Add Asana tags based on the PR diff
+### Set Asana custom fields based on the PR diff
 
-Looks for Asana task(s) linked in the PR description and adds Asana tags to them based on which files the Pull Request changed. The mapping from file paths to tag GIDs is provided inline via the `tag-map` input, so no extra Asana API calls are needed to resolve tag names — you supply tag GIDs directly.
+Looks for Asana task(s) linked in the PR description and sets custom field values on them based on which files the Pull Request changed. The mapping from file paths to custom field values is provided inline via the `custom-field-map` input, so no extra Asana API calls are needed to resolve names — you supply field GIDs (and, for enum fields, option GIDs) directly.
+
+This is typically run as a step immediately before `notify-pr-merged` in the same job, so a required custom field is guaranteed to be set before the task is completed (avoiding Asana's "field not set" reminder on closed tasks).
 
 ### `asana-pat`
 
@@ -650,18 +652,19 @@ Looks for Asana task(s) linked in the PR description and adds Asana tags to them
 
 **Optional** Prefix before the task i.e ASANA TASK: https://app.asana.com/1/2/3/. If not provided, any Asana URL in the text will be matched.
 
-### `tag-map`
+### `custom-field-map`
 
-**Required** JSON string mapping file-path glob patterns to Asana tag GIDs.
+**Required** JSON string mapping file-path glob patterns to an Asana `custom_fields` hash (field GID -> value).
 
 - A changed file is matched against each pattern using glob syntax: `*` matches within a single path segment, `**` matches across segments, and `?` matches a single non-`/` character. Exact paths also work.
-- A file may match multiple patterns, in which case all matching tags are added.
-- The special key `"*"` is a fallback tag applied to any changed file that did not match any other pattern.
-- All matching tag GIDs across all changed files are de-duplicated and applied to every linked task.
+- For enum (dropdown) fields the value is the enum option's GID; for text fields it is a string; for number fields a number.
+- Because a custom field holds a single value, specific patterns are applied in **declaration order** and the first entry to set a given field GID wins (so list more specific rules first).
+- The special key `"*"` is a fallback that only fills in fields that no specific pattern set. Keep a fallback if you want every linked task to always have the field set.
+- The resolved field values are merged and applied to every linked task in a single update.
 
 #### How timing works
 
-Steps within a single workflow job run sequentially in the order listed, so placing this step before a `notify-pr-merged` step in the same job guarantees tags are applied before the task is completed. Ordering is only non-deterministic if the tag step and the complete step live in separate workflows triggered by the same event (they would run in parallel). Note that completing an Asana task does not remove its tags, so tags can also be added to an already-completed task.
+Steps within a single workflow job run sequentially in the order listed, so placing this step before a `notify-pr-merged` step in the same job guarantees the field is set before the task is completed. Ordering is only non-deterministic if the two steps live in separate workflows triggered by the same event (they would run in parallel). If setting the field fails, that step fails and — by GitHub's default behaviour — the subsequent completion step is skipped, so a task is not closed without its field set.
 
 #### Example Usage
 
@@ -675,20 +678,22 @@ jobs:
         if: github.event.pull_request.merged
         runs-on: ubuntu-latest
         steps:
-            - name: Tag linked Asana tasks based on the diff
+            - name: Set Asana custom fields based on the diff
               uses: duckduckgo/native-github-asana-sync@v1.1
               with:
-                  action: 'add-asana-tags-from-diff'
+                  action: 'set-asana-custom-fields-from-diff'
                   asana-pat: ${{ secrets.asana_pat }}
                   github-pat: ${{ secrets.github_pat }}
                   github-org: ${{ github.repository_owner }}
                   github-repository: ${{ github.event.repository.name }}
                   github-pr: ${{ github.event.pull_request.number }}
                   trigger-phrase: 'Task/Issue URL:'
-                  tag-map: >-
+                  # field GID 1201111111111111 -> option A when feature-flags.json
+                  # changed, option B for any other change
+                  custom-field-map: >-
                       {
-                        "config/feature-flags.json": "1201111111111111",
-                        "*": "1202222222222222"
+                        "config/feature-flags.json": { "1201111111111111": "1209999999999991" },
+                        "*": { "1201111111111111": "1209999999999992" }
                       }
 
             - name: Complete linked Asana tasks

--- a/action.js
+++ b/action.js
@@ -435,9 +435,6 @@ function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
     const patterns = Object.entries(fieldMap).filter(([pattern]) => pattern !== '*');
     const resolved = {};
 
-    // Specific patterns are evaluated in declaration order; the first entry to
-    // set a given field GID wins, so list more specific rules first. A field can
-    // only hold one value, hence "first wins" rather than the union used for tags.
     for (const [pattern, fields] of patterns) {
         const anyFileMatches = changedFiles.some((file) => matchesGlob(pattern, file));
         if (!anyFileMatches) {

--- a/action.js
+++ b/action.js
@@ -430,25 +430,36 @@ function matchesGlob(pattern, filePath) {
     return globToRegExp(pattern).test(filePath);
 }
 
-function resolveTagsForFiles(tagMap, changedFiles) {
-    const fallbackTag = tagMap['*'];
-    const patterns = Object.entries(tagMap).filter(([pattern]) => pattern !== '*');
-    const tagGids = new Set();
+function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
+    const fallbackFields = fieldMap['*'];
+    const patterns = Object.entries(fieldMap).filter(([pattern]) => pattern !== '*');
+    const resolved = {};
 
-    for (const file of changedFiles) {
-        let matched = false;
-        for (const [pattern, tagGid] of patterns) {
-            if (matchesGlob(pattern, file)) {
-                tagGids.add(tagGid);
-                matched = true;
-            }
+    // Specific patterns are evaluated in declaration order; the first entry to
+    // set a given field GID wins, so list more specific rules first. A field can
+    // only hold one value, hence "first wins" rather than the union used for tags.
+    for (const [pattern, fields] of patterns) {
+        const anyFileMatches = changedFiles.some((file) => matchesGlob(pattern, file));
+        if (!anyFileMatches) {
+            continue;
         }
-        if (!matched && fallbackTag) {
-            tagGids.add(fallbackTag);
+        for (const [fieldGid, value] of Object.entries(fields)) {
+            if (!(fieldGid in resolved)) {
+                resolved[fieldGid] = value;
+            }
         }
     }
 
-    return [...tagGids];
+    // The "*" fallback only fills in fields that no specific pattern set.
+    if (fallbackFields) {
+        for (const [fieldGid, value] of Object.entries(fallbackFields)) {
+            if (!(fieldGid in resolved)) {
+                resolved[fieldGid] = value;
+            }
+        }
+    }
+
+    return resolved;
 }
 
 async function getChangedFiles(githubClient, owner, repo, pullNumber) {
@@ -478,51 +489,49 @@ async function getChangedFiles(githubClient, owner, repo, pullNumber) {
     return files;
 }
 
-async function addTagToTask(client, taskId, tagGid) {
+async function updateTaskCustomFields(client, taskId, customFields) {
     try {
-        const body = { data: { tag: tagGid } };
-        return await client.tasks.addTagForTask(body, taskId);
+        const body = { data: { custom_fields: customFields } };
+        return await client.tasks.updateTask(body, taskId, {});
     } catch (error) {
-        console.error(`Failed to add tag ${tagGid} to task ${taskId}:`, JSON.stringify(error));
-        core.setFailed(`Failed to add tag ${tagGid} to task ${taskId}`);
+        console.error(`Failed to set custom fields on task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Failed to set custom fields on task ${taskId}`);
     }
 }
 
-async function addTagsFromDiff() {
+async function setCustomFieldsFromDiff() {
     const githubPAT = core.getInput('github-pat', { required: true });
     const githubClient = buildGithubClient(githubPAT);
     const org = core.getInput('github-org', { required: true });
     const repo = core.getInput('github-repository', { required: true });
     const pullNumber = core.getInput('github-pr', { required: true });
-    const tagMapInput = core.getInput('tag-map', { required: true });
+    const fieldMapInput = core.getInput('custom-field-map', { required: true });
 
-    let tagMap;
+    let fieldMap;
     try {
-        tagMap = JSON.parse(tagMapInput);
+        fieldMap = JSON.parse(fieldMapInput);
     } catch (error) {
-        core.setFailed(`Invalid tag-map JSON: ${tagMapInput}`);
+        core.setFailed(`Invalid custom-field-map JSON: ${fieldMapInput}`);
         return;
     }
 
     const changedFiles = await getChangedFiles(githubClient, org, repo, pullNumber);
     console.info(`PR #${pullNumber} changed ${changedFiles.length} file(s)`);
 
-    const tagGids = resolveTagsForFiles(tagMap, changedFiles);
-    if (tagGids.length === 0) {
-        console.info('No tags matched the changed files; nothing to do');
+    const customFields = resolveCustomFieldsForFiles(fieldMap, changedFiles);
+    if (Object.keys(customFields).length === 0) {
+        console.info('No custom fields matched the changed files; nothing to do');
         return;
     }
-    console.info('Applying tags:', tagGids.join(','));
+    console.info('Setting custom fields:', JSON.stringify(customFields));
 
     const client = buildAsanaClient();
     const foundTasks = await findAsanaTasks();
 
     const taskIds = [];
     for (const taskId of foundTasks) {
-        for (const tagGid of tagGids) {
-            console.info(`Adding tag ${tagGid} to task ${taskId}`);
-            await addTagToTask(client, taskId, tagGid);
-        }
+        console.info(`Setting custom fields on task ${taskId}`);
+        await updateTaskCustomFields(client, taskId, customFields);
         taskIds.push(taskId);
     }
     return taskIds;
@@ -759,8 +768,8 @@ async function action() {
             await addTaskPRDescription();
             break;
         }
-        case 'add-asana-tags-from-diff': {
-            await addTagsFromDiff();
+        case 'set-asana-custom-fields-from-diff': {
+            await setCustomFieldsFromDiff();
             break;
         }
         case 'get-asana-user-id': {

--- a/action.js
+++ b/action.js
@@ -401,6 +401,133 @@ async function createAsanaTask() {
     return createTask(client, taskName, taskDescription, projectId, sectionId, tags, collaborators, assignee, customFields);
 }
 
+function globToRegExp(glob) {
+    let regex = '';
+    for (let i = 0; i < glob.length; i++) {
+        const char = glob[i];
+        if (char === '*') {
+            if (glob[i + 1] === '*') {
+                regex += '.*';
+                i++;
+            } else {
+                regex += '[^/]*';
+            }
+        } else if (char === '?') {
+            regex += '[^/]';
+        } else if ('.+^${}()|[]\\'.includes(char)) {
+            regex += `\\${char}`;
+        } else {
+            regex += char;
+        }
+    }
+    return new RegExp(`^${regex}$`);
+}
+
+function matchesGlob(pattern, filePath) {
+    if (pattern === filePath) {
+        return true;
+    }
+    return globToRegExp(pattern).test(filePath);
+}
+
+function resolveTagsForFiles(tagMap, changedFiles) {
+    const fallbackTag = tagMap['*'];
+    const patterns = Object.entries(tagMap).filter(([pattern]) => pattern !== '*');
+    const tagGids = new Set();
+
+    for (const file of changedFiles) {
+        let matched = false;
+        for (const [pattern, tagGid] of patterns) {
+            if (matchesGlob(pattern, file)) {
+                tagGids.add(tagGid);
+                matched = true;
+            }
+        }
+        if (!matched && fallbackTag) {
+            tagGids.add(fallbackTag);
+        }
+    }
+
+    return [...tagGids];
+}
+
+async function getChangedFiles(githubClient, owner, repo, pullNumber) {
+    const files = [];
+    const perPage = 100;
+    let page = 1;
+
+    while (true) {
+        const response = await githubClient.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/files', {
+            owner,
+            repo,
+            pull_number: pullNumber,
+            per_page: perPage,
+            page,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+        });
+        const data = response.data || [];
+        files.push(...data.map((file) => file.filename));
+        if (data.length < perPage) {
+            break;
+        }
+        page++;
+    }
+
+    return files;
+}
+
+async function addTagToTask(client, taskId, tagGid) {
+    try {
+        const body = { data: { tag: tagGid } };
+        return await client.tasks.addTagForTask(body, taskId);
+    } catch (error) {
+        console.error(`Failed to add tag ${tagGid} to task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Failed to add tag ${tagGid} to task ${taskId}`);
+    }
+}
+
+async function addTagsFromDiff() {
+    const githubPAT = core.getInput('github-pat', { required: true });
+    const githubClient = buildGithubClient(githubPAT);
+    const org = core.getInput('github-org', { required: true });
+    const repo = core.getInput('github-repository', { required: true });
+    const pullNumber = core.getInput('github-pr', { required: true });
+    const tagMapInput = core.getInput('tag-map', { required: true });
+
+    let tagMap;
+    try {
+        tagMap = JSON.parse(tagMapInput);
+    } catch (error) {
+        core.setFailed(`Invalid tag-map JSON: ${tagMapInput}`);
+        return;
+    }
+
+    const changedFiles = await getChangedFiles(githubClient, org, repo, pullNumber);
+    console.info(`PR #${pullNumber} changed ${changedFiles.length} file(s)`);
+
+    const tagGids = resolveTagsForFiles(tagMap, changedFiles);
+    if (tagGids.length === 0) {
+        console.info('No tags matched the changed files; nothing to do');
+        return;
+    }
+    console.info('Applying tags:', tagGids.join(','));
+
+    const client = buildAsanaClient();
+    const foundTasks = await findAsanaTasks();
+
+    const taskIds = [];
+    for (const taskId of foundTasks) {
+        for (const tagGid of tagGids) {
+            console.info(`Adding tag ${tagGid} to task ${taskId}`);
+            await addTagToTask(client, taskId, tagGid);
+        }
+        taskIds.push(taskId);
+    }
+    return taskIds;
+}
+
 async function addTaskPRDescription() {
     const githubPAT = core.getInput('github-pat');
     const githubClient = buildGithubClient(githubPAT);
@@ -630,6 +757,10 @@ async function action() {
         }
         case 'add-task-pr-description': {
             await addTaskPRDescription();
+            break;
+        }
+        case 'add-asana-tags-from-diff': {
+            await addTagsFromDiff();
             break;
         }
         case 'get-asana-user-id': {

--- a/action.js
+++ b/action.js
@@ -401,33 +401,32 @@ async function createAsanaTask() {
     return createTask(client, taskName, taskDescription, projectId, sectionId, tags, collaborators, assignee, customFields);
 }
 
-function globToRegExp(glob) {
-    let regex = '';
-    for (let i = 0; i < glob.length; i++) {
-        const char = glob[i];
-        if (char === '*') {
-            if (glob[i + 1] === '*') {
-                regex += '.*';
-                i++;
-            } else {
-                regex += '[^/]*';
-            }
-        } else if (char === '?') {
-            regex += '[^/]';
-        } else if ('.+^${}()|[]\\'.includes(char)) {
-            regex += `\\${char}`;
-        } else {
-            regex += char;
-        }
-    }
-    return new RegExp(`^${regex}$`);
-}
-
-function matchesGlob(pattern, filePath) {
+function matchesPattern(pattern, filePath) {
     if (pattern === filePath) {
         return true;
     }
-    return globToRegExp(pattern).test(filePath);
+
+    const hasLeadingStar = pattern.startsWith('*');
+    const hasTrailingStar = pattern.endsWith('*');
+
+    let literal = pattern;
+    while (literal.startsWith('*')) {
+        literal = literal.slice(1);
+    }
+    while (literal.endsWith('*')) {
+        literal = literal.slice(0, -1);
+    }
+
+    if (hasLeadingStar && hasTrailingStar) {
+        return literal === '' || filePath.includes(literal);
+    }
+    if (hasLeadingStar) {
+        return filePath.endsWith(literal);
+    }
+    if (hasTrailingStar) {
+        return filePath.startsWith(literal);
+    }
+    return false;
 }
 
 function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
@@ -436,7 +435,7 @@ function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
     const resolved = {};
 
     for (const [pattern, fields] of patterns) {
-        const anyFileMatches = changedFiles.some((file) => matchesGlob(pattern, file));
+        const anyFileMatches = changedFiles.some((file) => matchesPattern(pattern, file));
         if (!anyFileMatches) {
             continue;
         }

--- a/action.js
+++ b/action.js
@@ -51,6 +51,50 @@ function getArrayFromInput(input) {
         : [];
 }
 
+function formatErrorMessage(error) {
+    if (error?.message) {
+        return error.message;
+    }
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return String(error);
+    }
+}
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseCustomFieldsHash(jsonInput, failureLabel) {
+    let parsed;
+    try {
+        parsed = JSON.parse(jsonInput);
+    } catch (error) {
+        core.setFailed(`Invalid ${failureLabel} JSON: ${jsonInput}`);
+        return null;
+    }
+    if (!isPlainObject(parsed)) {
+        core.setFailed(`${failureLabel} must be a JSON object`);
+        return null;
+    }
+    return parsed;
+}
+
+function parseCustomFieldMap(fieldMapInput) {
+    const fieldMap = parseCustomFieldsHash(fieldMapInput, 'custom-field-map');
+    if (fieldMap === null) {
+        return null;
+    }
+    for (const [pattern, fields] of Object.entries(fieldMap)) {
+        if (!isPlainObject(fields)) {
+            core.setFailed(`custom-field-map entry for "${pattern}" must be a JSON object`);
+            return null;
+        }
+    }
+    return fieldMap;
+}
+
 async function isTaskInProject(taskId, projectId) {
     const client = buildAsanaClient();
     try {
@@ -65,6 +109,10 @@ async function isTaskInProject(taskId, projectId) {
 async function findAsanaTasks() {
     const triggerPhrase = core.getInput('trigger-phrase');
     const pullRequest = github.context.payload.pull_request;
+    if (!pullRequest?.body) {
+        console.info('No pull request context available for task discovery');
+        return [];
+    }
     const regexString = `${triggerPhrase}\\s*https:\\/\\/app.asana.com\\/(\\d+)\\/((\\d+)\\/)?(project\\/)?(?<project>\\d+)(\\/task)?\\/(?<task>\\d+).*?`;
     const specifiedProjectId = core.getInput('asana-project');
     const regex = new RegExp(regexString, 'g');
@@ -197,11 +245,8 @@ async function updateTaskCustomFieldsAction() {
         return;
     }
 
-    let customFields;
-    try {
-        customFields = JSON.parse(customFieldsInput);
-    } catch (error) {
-        core.setFailed(`Invalid custom fields JSON: ${customFieldsInput}`);
+    const customFields = parseCustomFieldsHash(customFieldsInput, 'custom fields');
+    if (customFields === null) {
         return;
     }
 
@@ -213,7 +258,7 @@ async function updateTaskCustomFieldsAction() {
             console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
             const remaining = taskIds.slice(i + 1);
             const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
-            core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}.${suffix}`);
+            core.setFailed(`Error updating custom fields on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
             return;
         }
     }
@@ -532,11 +577,8 @@ async function setCustomFieldsFromDiff() {
     const pullNumber = core.getInput('github-pr', { required: true });
     const fieldMapInput = core.getInput('custom-field-map', { required: true });
 
-    let fieldMap;
-    try {
-        fieldMap = JSON.parse(fieldMapInput);
-    } catch (error) {
-        core.setFailed(`Invalid custom-field-map JSON: ${fieldMapInput}`);
+    const fieldMap = parseCustomFieldMap(fieldMapInput);
+    if (fieldMap === null) {
         return;
     }
 
@@ -561,7 +603,7 @@ async function setCustomFieldsFromDiff() {
             console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
             const remaining = foundTasks.slice(i + 1);
             const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
-            core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}.${suffix}`);
+            core.setFailed(`Error updating custom fields on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
             return;
         }
     }

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ inputs:
         description: 'Github Pull Request number.'
         required: false
     custom-field-map:
-        description: 'JSON mapping file-path glob patterns to an Asana custom_fields hash (field GID -> value).'
+        description: 'JSON mapping file-path patterns to an Asana custom_fields hash (field GID -> value).'
         required: false
     pr-review-state:
         description: 'State of the Pull Request Review [approved | changes_requested | commented].'

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ inputs:
         description: 'Github Pull Request number.'
         required: false
     custom-field-map:
-        description: 'JSON string mapping file-path glob patterns to an Asana custom_fields hash (field GID -> value), used by set-asana-custom-fields-from-diff. A file matches a pattern using glob syntax (* within a path segment, ** across segments). Specific patterns are applied in declaration order and the first to set a given field GID wins; the special key "*" is a fallback that only fills in fields no specific pattern set. i.e. {"config/feature-flags.json":{"1201111111111111":"OPTION_GID_A"},"*":{"1201111111111111":"OPTION_GID_B"}}.'
+        description: 'JSON mapping file-path glob patterns to an Asana custom_fields hash (field GID -> value).'
         required: false
     pr-review-state:
         description: 'State of the Pull Request Review [approved | changes_requested | commented].'

--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,8 @@ inputs:
     github-pr:
         description: 'Github Pull Request number.'
         required: false
-    tag-map:
-        description: 'JSON string mapping file-path glob patterns to Asana tag GIDs, used by add-asana-tags-from-diff. A file matches a pattern using glob syntax (* matches within a path segment, ** across segments). The special key "*" is a fallback tag applied to any changed file that matched no other pattern. i.e. {"config/feature-flags.json":"1201111111111111","*":"1202222222222222"}.'
+    custom-field-map:
+        description: 'JSON string mapping file-path glob patterns to an Asana custom_fields hash (field GID -> value), used by set-asana-custom-fields-from-diff. A file matches a pattern using glob syntax (* within a path segment, ** across segments). Specific patterns are applied in declaration order and the first to set a given field GID wins; the special key "*" is a fallback that only fills in fields no specific pattern set. i.e. {"config/feature-flags.json":{"1201111111111111":"OPTION_GID_A"},"*":{"1201111111111111":"OPTION_GID_B"}}.'
         required: false
     pr-review-state:
         description: 'State of the Pull Request Review [approved | changes_requested | commented].'

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,12 @@ inputs:
     github-username:
         description: 'Github Username.'
         required: false
+    github-pr:
+        description: 'Github Pull Request number.'
+        required: false
+    tag-map:
+        description: 'JSON string mapping file-path glob patterns to Asana tag GIDs, used by add-asana-tags-from-diff. A file matches a pattern using glob syntax (* matches within a path segment, ** across segments). The special key "*" is a fallback tag applied to any changed file that matched no other pattern. i.e. {"config/feature-flags.json":"1201111111111111","*":"1202222222222222"}.'
+        required: false
     pr-review-state:
         description: 'State of the Pull Request Review [approved | changes_requested | commented].'
         required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -407,33 +407,32 @@ async function createAsanaTask() {
     return createTask(client, taskName, taskDescription, projectId, sectionId, tags, collaborators, assignee, customFields);
 }
 
-function globToRegExp(glob) {
-    let regex = '';
-    for (let i = 0; i < glob.length; i++) {
-        const char = glob[i];
-        if (char === '*') {
-            if (glob[i + 1] === '*') {
-                regex += '.*';
-                i++;
-            } else {
-                regex += '[^/]*';
-            }
-        } else if (char === '?') {
-            regex += '[^/]';
-        } else if ('.+^${}()|[]\\'.includes(char)) {
-            regex += `\\${char}`;
-        } else {
-            regex += char;
-        }
-    }
-    return new RegExp(`^${regex}$`);
-}
-
-function matchesGlob(pattern, filePath) {
+function matchesPattern(pattern, filePath) {
     if (pattern === filePath) {
         return true;
     }
-    return globToRegExp(pattern).test(filePath);
+
+    const hasLeadingStar = pattern.startsWith('*');
+    const hasTrailingStar = pattern.endsWith('*');
+
+    let literal = pattern;
+    while (literal.startsWith('*')) {
+        literal = literal.slice(1);
+    }
+    while (literal.endsWith('*')) {
+        literal = literal.slice(0, -1);
+    }
+
+    if (hasLeadingStar && hasTrailingStar) {
+        return literal === '' || filePath.includes(literal);
+    }
+    if (hasLeadingStar) {
+        return filePath.endsWith(literal);
+    }
+    if (hasTrailingStar) {
+        return filePath.startsWith(literal);
+    }
+    return false;
 }
 
 function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
@@ -442,7 +441,7 @@ function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
     const resolved = {};
 
     for (const [pattern, fields] of patterns) {
-        const anyFileMatches = changedFiles.some((file) => matchesGlob(pattern, file));
+        const anyFileMatches = changedFiles.some((file) => matchesPattern(pattern, file));
         if (!anyFileMatches) {
             continue;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -407,6 +407,133 @@ async function createAsanaTask() {
     return createTask(client, taskName, taskDescription, projectId, sectionId, tags, collaborators, assignee, customFields);
 }
 
+function globToRegExp(glob) {
+    let regex = '';
+    for (let i = 0; i < glob.length; i++) {
+        const char = glob[i];
+        if (char === '*') {
+            if (glob[i + 1] === '*') {
+                regex += '.*';
+                i++;
+            } else {
+                regex += '[^/]*';
+            }
+        } else if (char === '?') {
+            regex += '[^/]';
+        } else if ('.+^${}()|[]\\'.includes(char)) {
+            regex += `\\${char}`;
+        } else {
+            regex += char;
+        }
+    }
+    return new RegExp(`^${regex}$`);
+}
+
+function matchesGlob(pattern, filePath) {
+    if (pattern === filePath) {
+        return true;
+    }
+    return globToRegExp(pattern).test(filePath);
+}
+
+function resolveTagsForFiles(tagMap, changedFiles) {
+    const fallbackTag = tagMap['*'];
+    const patterns = Object.entries(tagMap).filter(([pattern]) => pattern !== '*');
+    const tagGids = new Set();
+
+    for (const file of changedFiles) {
+        let matched = false;
+        for (const [pattern, tagGid] of patterns) {
+            if (matchesGlob(pattern, file)) {
+                tagGids.add(tagGid);
+                matched = true;
+            }
+        }
+        if (!matched && fallbackTag) {
+            tagGids.add(fallbackTag);
+        }
+    }
+
+    return [...tagGids];
+}
+
+async function getChangedFiles(githubClient, owner, repo, pullNumber) {
+    const files = [];
+    const perPage = 100;
+    let page = 1;
+
+    while (true) {
+        const response = await githubClient.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/files', {
+            owner,
+            repo,
+            pull_number: pullNumber,
+            per_page: perPage,
+            page,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+        });
+        const data = response.data || [];
+        files.push(...data.map((file) => file.filename));
+        if (data.length < perPage) {
+            break;
+        }
+        page++;
+    }
+
+    return files;
+}
+
+async function addTagToTask(client, taskId, tagGid) {
+    try {
+        const body = { data: { tag: tagGid } };
+        return await client.tasks.addTagForTask(body, taskId);
+    } catch (error) {
+        console.error(`Failed to add tag ${tagGid} to task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Failed to add tag ${tagGid} to task ${taskId}`);
+    }
+}
+
+async function addTagsFromDiff() {
+    const githubPAT = core.getInput('github-pat', { required: true });
+    const githubClient = buildGithubClient(githubPAT);
+    const org = core.getInput('github-org', { required: true });
+    const repo = core.getInput('github-repository', { required: true });
+    const pullNumber = core.getInput('github-pr', { required: true });
+    const tagMapInput = core.getInput('tag-map', { required: true });
+
+    let tagMap;
+    try {
+        tagMap = JSON.parse(tagMapInput);
+    } catch (error) {
+        core.setFailed(`Invalid tag-map JSON: ${tagMapInput}`);
+        return;
+    }
+
+    const changedFiles = await getChangedFiles(githubClient, org, repo, pullNumber);
+    console.info(`PR #${pullNumber} changed ${changedFiles.length} file(s)`);
+
+    const tagGids = resolveTagsForFiles(tagMap, changedFiles);
+    if (tagGids.length === 0) {
+        console.info('No tags matched the changed files; nothing to do');
+        return;
+    }
+    console.info('Applying tags:', tagGids.join(','));
+
+    const client = buildAsanaClient();
+    const foundTasks = await findAsanaTasks();
+
+    const taskIds = [];
+    for (const taskId of foundTasks) {
+        for (const tagGid of tagGids) {
+            console.info(`Adding tag ${tagGid} to task ${taskId}`);
+            await addTagToTask(client, taskId, tagGid);
+        }
+        taskIds.push(taskId);
+    }
+    return taskIds;
+}
+
 async function addTaskPRDescription() {
     const githubPAT = core.getInput('github-pat');
     const githubClient = buildGithubClient(githubPAT);
@@ -636,6 +763,10 @@ async function action() {
         }
         case 'add-task-pr-description': {
             await addTaskPRDescription();
+            break;
+        }
+        case 'add-asana-tags-from-diff': {
+            await addTagsFromDiff();
             break;
         }
         case 'get-asana-user-id': {

--- a/dist/index.js
+++ b/dist/index.js
@@ -436,25 +436,36 @@ function matchesGlob(pattern, filePath) {
     return globToRegExp(pattern).test(filePath);
 }
 
-function resolveTagsForFiles(tagMap, changedFiles) {
-    const fallbackTag = tagMap['*'];
-    const patterns = Object.entries(tagMap).filter(([pattern]) => pattern !== '*');
-    const tagGids = new Set();
+function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
+    const fallbackFields = fieldMap['*'];
+    const patterns = Object.entries(fieldMap).filter(([pattern]) => pattern !== '*');
+    const resolved = {};
 
-    for (const file of changedFiles) {
-        let matched = false;
-        for (const [pattern, tagGid] of patterns) {
-            if (matchesGlob(pattern, file)) {
-                tagGids.add(tagGid);
-                matched = true;
-            }
+    // Specific patterns are evaluated in declaration order; the first entry to
+    // set a given field GID wins, so list more specific rules first. A field can
+    // only hold one value, hence "first wins" rather than the union used for tags.
+    for (const [pattern, fields] of patterns) {
+        const anyFileMatches = changedFiles.some((file) => matchesGlob(pattern, file));
+        if (!anyFileMatches) {
+            continue;
         }
-        if (!matched && fallbackTag) {
-            tagGids.add(fallbackTag);
+        for (const [fieldGid, value] of Object.entries(fields)) {
+            if (!(fieldGid in resolved)) {
+                resolved[fieldGid] = value;
+            }
         }
     }
 
-    return [...tagGids];
+    // The "*" fallback only fills in fields that no specific pattern set.
+    if (fallbackFields) {
+        for (const [fieldGid, value] of Object.entries(fallbackFields)) {
+            if (!(fieldGid in resolved)) {
+                resolved[fieldGid] = value;
+            }
+        }
+    }
+
+    return resolved;
 }
 
 async function getChangedFiles(githubClient, owner, repo, pullNumber) {
@@ -484,51 +495,49 @@ async function getChangedFiles(githubClient, owner, repo, pullNumber) {
     return files;
 }
 
-async function addTagToTask(client, taskId, tagGid) {
+async function updateTaskCustomFields(client, taskId, customFields) {
     try {
-        const body = { data: { tag: tagGid } };
-        return await client.tasks.addTagForTask(body, taskId);
+        const body = { data: { custom_fields: customFields } };
+        return await client.tasks.updateTask(body, taskId, {});
     } catch (error) {
-        console.error(`Failed to add tag ${tagGid} to task ${taskId}:`, JSON.stringify(error));
-        core.setFailed(`Failed to add tag ${tagGid} to task ${taskId}`);
+        console.error(`Failed to set custom fields on task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Failed to set custom fields on task ${taskId}`);
     }
 }
 
-async function addTagsFromDiff() {
+async function setCustomFieldsFromDiff() {
     const githubPAT = core.getInput('github-pat', { required: true });
     const githubClient = buildGithubClient(githubPAT);
     const org = core.getInput('github-org', { required: true });
     const repo = core.getInput('github-repository', { required: true });
     const pullNumber = core.getInput('github-pr', { required: true });
-    const tagMapInput = core.getInput('tag-map', { required: true });
+    const fieldMapInput = core.getInput('custom-field-map', { required: true });
 
-    let tagMap;
+    let fieldMap;
     try {
-        tagMap = JSON.parse(tagMapInput);
+        fieldMap = JSON.parse(fieldMapInput);
     } catch (error) {
-        core.setFailed(`Invalid tag-map JSON: ${tagMapInput}`);
+        core.setFailed(`Invalid custom-field-map JSON: ${fieldMapInput}`);
         return;
     }
 
     const changedFiles = await getChangedFiles(githubClient, org, repo, pullNumber);
     console.info(`PR #${pullNumber} changed ${changedFiles.length} file(s)`);
 
-    const tagGids = resolveTagsForFiles(tagMap, changedFiles);
-    if (tagGids.length === 0) {
-        console.info('No tags matched the changed files; nothing to do');
+    const customFields = resolveCustomFieldsForFiles(fieldMap, changedFiles);
+    if (Object.keys(customFields).length === 0) {
+        console.info('No custom fields matched the changed files; nothing to do');
         return;
     }
-    console.info('Applying tags:', tagGids.join(','));
+    console.info('Setting custom fields:', JSON.stringify(customFields));
 
     const client = buildAsanaClient();
     const foundTasks = await findAsanaTasks();
 
     const taskIds = [];
     for (const taskId of foundTasks) {
-        for (const tagGid of tagGids) {
-            console.info(`Adding tag ${tagGid} to task ${taskId}`);
-            await addTagToTask(client, taskId, tagGid);
-        }
+        console.info(`Setting custom fields on task ${taskId}`);
+        await updateTaskCustomFields(client, taskId, customFields);
         taskIds.push(taskId);
     }
     return taskIds;
@@ -765,8 +774,8 @@ async function action() {
             await addTaskPRDescription();
             break;
         }
-        case 'add-asana-tags-from-diff': {
-            await addTagsFromDiff();
+        case 'set-asana-custom-fields-from-diff': {
+            await setCustomFieldsFromDiff();
             break;
         }
         case 'get-asana-user-id': {

--- a/dist/index.js
+++ b/dist/index.js
@@ -441,9 +441,6 @@ function resolveCustomFieldsForFiles(fieldMap, changedFiles) {
     const patterns = Object.entries(fieldMap).filter(([pattern]) => pattern !== '*');
     const resolved = {};
 
-    // Specific patterns are evaluated in declaration order; the first entry to
-    // set a given field GID wins, so list more specific rules first. A field can
-    // only hold one value, hence "first wins" rather than the union used for tags.
     for (const [pattern, fields] of patterns) {
         const anyFileMatches = changedFiles.some((file) => matchesGlob(pattern, file));
         if (!anyFileMatches) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -57,6 +57,50 @@ function getArrayFromInput(input) {
         : [];
 }
 
+function formatErrorMessage(error) {
+    if (error?.message) {
+        return error.message;
+    }
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return String(error);
+    }
+}
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseCustomFieldsHash(jsonInput, failureLabel) {
+    let parsed;
+    try {
+        parsed = JSON.parse(jsonInput);
+    } catch (error) {
+        core.setFailed(`Invalid ${failureLabel} JSON: ${jsonInput}`);
+        return null;
+    }
+    if (!isPlainObject(parsed)) {
+        core.setFailed(`${failureLabel} must be a JSON object`);
+        return null;
+    }
+    return parsed;
+}
+
+function parseCustomFieldMap(fieldMapInput) {
+    const fieldMap = parseCustomFieldsHash(fieldMapInput, 'custom-field-map');
+    if (fieldMap === null) {
+        return null;
+    }
+    for (const [pattern, fields] of Object.entries(fieldMap)) {
+        if (!isPlainObject(fields)) {
+            core.setFailed(`custom-field-map entry for "${pattern}" must be a JSON object`);
+            return null;
+        }
+    }
+    return fieldMap;
+}
+
 async function isTaskInProject(taskId, projectId) {
     const client = buildAsanaClient();
     try {
@@ -71,6 +115,10 @@ async function isTaskInProject(taskId, projectId) {
 async function findAsanaTasks() {
     const triggerPhrase = core.getInput('trigger-phrase');
     const pullRequest = github.context.payload.pull_request;
+    if (!pullRequest?.body) {
+        console.info('No pull request context available for task discovery');
+        return [];
+    }
     const regexString = `${triggerPhrase}\\s*https:\\/\\/app.asana.com\\/(\\d+)\\/((\\d+)\\/)?(project\\/)?(?<project>\\d+)(\\/task)?\\/(?<task>\\d+).*?`;
     const specifiedProjectId = core.getInput('asana-project');
     const regex = new RegExp(regexString, 'g');
@@ -203,11 +251,8 @@ async function updateTaskCustomFieldsAction() {
         return;
     }
 
-    let customFields;
-    try {
-        customFields = JSON.parse(customFieldsInput);
-    } catch (error) {
-        core.setFailed(`Invalid custom fields JSON: ${customFieldsInput}`);
+    const customFields = parseCustomFieldsHash(customFieldsInput, 'custom fields');
+    if (customFields === null) {
         return;
     }
 
@@ -219,7 +264,7 @@ async function updateTaskCustomFieldsAction() {
             console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
             const remaining = taskIds.slice(i + 1);
             const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
-            core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}.${suffix}`);
+            core.setFailed(`Error updating custom fields on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
             return;
         }
     }
@@ -538,11 +583,8 @@ async function setCustomFieldsFromDiff() {
     const pullNumber = core.getInput('github-pr', { required: true });
     const fieldMapInput = core.getInput('custom-field-map', { required: true });
 
-    let fieldMap;
-    try {
-        fieldMap = JSON.parse(fieldMapInput);
-    } catch (error) {
-        core.setFailed(`Invalid custom-field-map JSON: ${fieldMapInput}`);
+    const fieldMap = parseCustomFieldMap(fieldMapInput);
+    if (fieldMap === null) {
         return;
     }
 
@@ -567,7 +609,7 @@ async function setCustomFieldsFromDiff() {
             console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
             const remaining = foundTasks.slice(i + 1);
             const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
-            core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}.${suffix}`);
+            core.setFailed(`Error updating custom fields on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
             return;
         }
     }

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -102,7 +102,6 @@ const mockAsanaClient = {
         updateTask: jest.fn().mockResolvedValue({}),
         getTasksForSection: jest.fn().mockResolvedValue({ data: [] }), // Default: no existing tasks
         getTask: jest.fn().mockResolvedValue(mockAsanaTask),
-        addTagForTask: jest.fn().mockResolvedValue({}),
     },
     sections: {
         addTaskForSection: jest.fn().mockResolvedValue({}),
@@ -1314,9 +1313,12 @@ describe('GitHub Asana Sync Action', () => {
         });
     });
 
-    describe('action: add-asana-tags-from-diff', () => {
+    describe('action: set-asana-custom-fields-from-diff', () => {
+        const fieldGid = '1201111111111111';
+        const optionA = '1209999999999991';
+        const optionB = '1209999999999992';
         const baseInputs = {
-            action: 'add-asana-tags-from-diff',
+            action: 'set-asana-custom-fields-from-diff',
             'asana-pat': 'mock-asana-pat',
             'github-pat': 'mock-github-pat',
             'github-org': 'test-owner',
@@ -1325,10 +1327,13 @@ describe('GitHub Asana Sync Action', () => {
             'trigger-phrase': 'Closes', // resolves to task 2222 from the PR body
         };
 
-        it('should add the matched tag and the fallback tag based on changed files', async () => {
+        it('should set the specific field value when the matching file changed (first match wins)', async () => {
             mockGetInput({
                 ...baseInputs,
-                'tag-map': JSON.stringify({ 'config/feature-flags.json': 'tagA', '*': 'tagB' }),
+                'custom-field-map': JSON.stringify({
+                    'config/feature-flags.json': { [fieldGid]: optionA },
+                    '*': { [fieldGid]: optionB },
+                }),
             });
             github.context.payload.issue = undefined;
             mockOctokitRequest.mockResolvedValueOnce({
@@ -1341,16 +1346,19 @@ describe('GitHub Asana Sync Action', () => {
                 'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
                 expect.objectContaining({ owner: 'test-owner', repo: 'test-repo', pull_number: '123' }),
             );
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledTimes(2);
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagA' } }, '2222');
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagB' } }, '2222');
+            // Specific pattern wins over the fallback for the same field GID
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith({ data: { custom_fields: { [fieldGid]: optionA } } }, '2222', {});
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should apply only the fallback tag when no specific pattern matches', async () => {
+        it('should apply the fallback field value when no specific pattern matches', async () => {
             mockGetInput({
                 ...baseInputs,
-                'tag-map': JSON.stringify({ 'config/feature-flags.json': 'tagA', '*': 'tagB' }),
+                'custom-field-map': JSON.stringify({
+                    'config/feature-flags.json': { [fieldGid]: optionA },
+                    '*': { [fieldGid]: optionB },
+                }),
             });
             github.context.payload.issue = undefined;
             mockOctokitRequest.mockResolvedValueOnce({
@@ -1359,15 +1367,19 @@ describe('GitHub Asana Sync Action', () => {
 
             await action();
 
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledTimes(1);
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagB' } }, '2222');
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith({ data: { custom_fields: { [fieldGid]: optionB } } }, '2222', {});
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should support glob patterns spanning path segments', async () => {
+        it('should merge a specific field and a different fallback field using glob matching', async () => {
+            const otherField = '1203333333333333';
             mockGetInput({
                 ...baseInputs,
-                'tag-map': JSON.stringify({ 'src/**': 'tagSrc', '**/*.sql': 'tagSql' }),
+                'custom-field-map': JSON.stringify({
+                    'src/**': { [fieldGid]: optionA },
+                    '*': { [otherField]: 'fallback-value' },
+                }),
             });
             github.context.payload.issue = undefined;
             mockOctokitRequest.mockResolvedValueOnce({
@@ -1376,17 +1388,20 @@ describe('GitHub Asana Sync Action', () => {
 
             await action();
 
-            // file matches both src/** and **/*.sql -> both tags added once
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledTimes(2);
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagSrc' } }, '2222');
-            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagSql' } }, '2222');
+            // src/** sets fieldGid; fallback fills the (different) otherField
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
+                { data: { custom_fields: { [fieldGid]: optionA, [otherField]: 'fallback-value' } } },
+                '2222',
+                {},
+            );
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should do nothing when no tags match and no fallback is provided', async () => {
+        it('should do nothing when no pattern matches and no fallback is provided', async () => {
             mockGetInput({
                 ...baseInputs,
-                'tag-map': JSON.stringify({ 'config/feature-flags.json': 'tagA' }),
+                'custom-field-map': JSON.stringify({ 'config/feature-flags.json': { [fieldGid]: optionA } }),
             });
             github.context.payload.issue = undefined;
             mockOctokitRequest.mockResolvedValueOnce({
@@ -1395,21 +1410,21 @@ describe('GitHub Asana Sync Action', () => {
 
             await action();
 
-            expect(mockAsanaClient.tasks.addTagForTask).not.toHaveBeenCalled();
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should fail on invalid tag-map JSON', async () => {
+        it('should fail on invalid custom-field-map JSON', async () => {
             mockGetInput({
                 ...baseInputs,
-                'tag-map': '{not valid json',
+                'custom-field-map': '{not valid json',
             });
             github.context.payload.issue = undefined;
 
             await action();
 
-            expect(mockAsanaClient.tasks.addTagForTask).not.toHaveBeenCalled();
-            expect(core.setFailed).toHaveBeenCalledWith('Invalid tag-map JSON: {not valid json');
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('Invalid custom-field-map JSON: {not valid json');
         });
     });
 

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -549,6 +549,20 @@ describe('GitHub Asana Sync Action', () => {
             );
             expect(core.setFailed).not.toHaveBeenCalled();
         });
+
+        it('should fail if no task IDs are provided outside a pull request event', async () => {
+            github.context.payload.pull_request = undefined;
+            mockGetInput({
+                action: 'add-task-asana-project',
+                'asana-pat': 'mock-asana-pat',
+                'asana-project': mockAsanaProject,
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.addProjectForTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('No valid task IDs provided');
+        });
     });
 
     describe('action: update-task-custom-fields', () => {
@@ -590,6 +604,20 @@ describe('GitHub Asana Sync Action', () => {
 
             expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
             expect(core.setFailed).toHaveBeenCalledWith('Invalid custom fields JSON: not-json');
+        });
+
+        it('should fail when JSON is not an object', async () => {
+            mockGetInput({
+                action: 'update-task-custom-fields',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': taskIdsToUpdate,
+                'asana-task-custom-fields': '[]',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('custom fields must be a JSON object');
         });
 
         it('should fail when no task IDs are provided', async () => {
@@ -1547,6 +1575,32 @@ describe('GitHub Asana Sync Action', () => {
 
             expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
             expect(core.setFailed).toHaveBeenCalledWith('Invalid custom-field-map JSON: {not valid json');
+        });
+
+        it('should fail when custom-field-map is not an object', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'custom-field-map': 'null',
+            });
+            github.context.payload.issue = undefined;
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('custom-field-map must be a JSON object');
+        });
+
+        it('should fail when a custom-field-map pattern value is not an object', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'custom-field-map': JSON.stringify({ 'src/*': 'not-an-object' }),
+            });
+            github.context.payload.issue = undefined;
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('custom-field-map entry for "src/*" must be a JSON object');
         });
 
         it('should update all linked tasks from the PR body', async () => {

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -102,6 +102,7 @@ const mockAsanaClient = {
         updateTask: jest.fn().mockResolvedValue({}),
         getTasksForSection: jest.fn().mockResolvedValue({ data: [] }), // Default: no existing tasks
         getTask: jest.fn().mockResolvedValue(mockAsanaTask),
+        addTagForTask: jest.fn().mockResolvedValue({}),
     },
     sections: {
         addTaskForSection: jest.fn().mockResolvedValue({}),
@@ -1310,6 +1311,105 @@ describe('GitHub Asana Sync Action', () => {
                 {},
             );
             expect(core.setFailed).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('action: add-asana-tags-from-diff', () => {
+        const baseInputs = {
+            action: 'add-asana-tags-from-diff',
+            'asana-pat': 'mock-asana-pat',
+            'github-pat': 'mock-github-pat',
+            'github-org': 'test-owner',
+            'github-repository': 'test-repo',
+            'github-pr': '123',
+            'trigger-phrase': 'Closes', // resolves to task 2222 from the PR body
+        };
+
+        it('should add the matched tag and the fallback tag based on changed files', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'tag-map': JSON.stringify({ 'config/feature-flags.json': 'tagA', '*': 'tagB' }),
+            });
+            github.context.payload.issue = undefined;
+            mockOctokitRequest.mockResolvedValueOnce({
+                data: [{ filename: 'config/feature-flags.json' }, { filename: 'src/app.js' }],
+            });
+
+            await action();
+
+            expect(mockOctokitRequest).toHaveBeenCalledWith(
+                'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
+                expect.objectContaining({ owner: 'test-owner', repo: 'test-repo', pull_number: '123' }),
+            );
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledTimes(2);
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagA' } }, '2222');
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagB' } }, '2222');
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should apply only the fallback tag when no specific pattern matches', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'tag-map': JSON.stringify({ 'config/feature-flags.json': 'tagA', '*': 'tagB' }),
+            });
+            github.context.payload.issue = undefined;
+            mockOctokitRequest.mockResolvedValueOnce({
+                data: [{ filename: 'src/app.js' }, { filename: 'README.md' }],
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledTimes(1);
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagB' } }, '2222');
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should support glob patterns spanning path segments', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'tag-map': JSON.stringify({ 'src/**': 'tagSrc', '**/*.sql': 'tagSql' }),
+            });
+            github.context.payload.issue = undefined;
+            mockOctokitRequest.mockResolvedValueOnce({
+                data: [{ filename: 'src/db/migrations/001.sql' }],
+            });
+
+            await action();
+
+            // file matches both src/** and **/*.sql -> both tags added once
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledTimes(2);
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagSrc' } }, '2222');
+            expect(mockAsanaClient.tasks.addTagForTask).toHaveBeenCalledWith({ data: { tag: 'tagSql' } }, '2222');
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should do nothing when no tags match and no fallback is provided', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'tag-map': JSON.stringify({ 'config/feature-flags.json': 'tagA' }),
+            });
+            github.context.payload.issue = undefined;
+            mockOctokitRequest.mockResolvedValueOnce({
+                data: [{ filename: 'src/app.js' }],
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.addTagForTask).not.toHaveBeenCalled();
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should fail on invalid tag-map JSON', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'tag-map': '{not valid json',
+            });
+            github.context.payload.issue = undefined;
+
+            await action();
+
+            expect(mockAsanaClient.tasks.addTagForTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('Invalid tag-map JSON: {not valid json');
         });
     });
 

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -1563,21 +1563,9 @@ describe('GitHub Asana Sync Action', () => {
             await action();
 
             expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(3);
-            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
-                { data: { custom_fields: { [fieldGid]: optionB } } },
-                '2222',
-                {},
-            );
-            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
-                { data: { custom_fields: { [fieldGid]: optionB } } },
-                '3333',
-                {},
-            );
-            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
-                { data: { custom_fields: { [fieldGid]: optionB } } },
-                '4444',
-                {},
-            );
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith({ data: { custom_fields: { [fieldGid]: optionB } } }, '2222', {});
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith({ data: { custom_fields: { [fieldGid]: optionB } } }, '3333', {});
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith({ data: { custom_fields: { [fieldGid]: optionB } } }, '4444', {});
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
@@ -1601,9 +1589,7 @@ describe('GitHub Asana Sync Action', () => {
             expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(expect.anything(), '2222', {});
             expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(expect.anything(), '3333', {});
             expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalledWith(expect.anything(), '4444', {});
-            expect(core.setFailed).toHaveBeenCalledWith(
-                'Error updating custom fields on task 3333: boom. Skipped remaining tasks: 4444.',
-            );
+            expect(core.setFailed).toHaveBeenCalledWith('Error updating custom fields on task 3333: boom. Skipped remaining tasks: 4444.');
         });
     });
 

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -1372,12 +1372,12 @@ describe('GitHub Asana Sync Action', () => {
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should merge a specific field and a different fallback field using glob matching', async () => {
+        it('should merge a prefix-matched field and a different fallback field', async () => {
             const otherField = '1203333333333333';
             mockGetInput({
                 ...baseInputs,
                 'custom-field-map': JSON.stringify({
-                    'src/**': { [fieldGid]: optionA },
+                    'src/*': { [fieldGid]: optionA },
                     '*': { [otherField]: 'fallback-value' },
                 }),
             });
@@ -1388,13 +1388,30 @@ describe('GitHub Asana Sync Action', () => {
 
             await action();
 
-            // src/** sets fieldGid; fallback fills the (different) otherField
+            // src/* prefix matches the nested file and sets fieldGid; fallback fills the (different) otherField
             expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
             expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
                 { data: { custom_fields: { [fieldGid]: optionA, [otherField]: 'fallback-value' } } },
                 '2222',
                 {},
             );
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should match a suffix pattern with a leading star', async () => {
+            mockGetInput({
+                ...baseInputs,
+                'custom-field-map': JSON.stringify({ '*.sql': { [fieldGid]: optionA } }),
+            });
+            github.context.payload.issue = undefined;
+            mockOctokitRequest.mockResolvedValueOnce({
+                data: [{ filename: 'db/migrations/001.sql' }],
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith({ data: { custom_fields: { [fieldGid]: optionA } } }, '2222', {});
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/137249556945/project/1206670747178362/task/1215596249841032?focus=true

Allows users to set up automation that sets custom field values on tasks based on which files were changed in a PR. This will help us in the breakage pipeline as our metrics require certain fields, which we otherwise have to nag on filling with asana-side automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The action writes to production Asana tasks using PATs and pattern logic where misconfiguration could set wrong enum GIDs; scope is limited to existing update-task flows and is well covered by tests.
> 
> **Overview**
> Adds a new **`set-asana-custom-fields-from-diff`** action that loads a PR’s changed files via the GitHub API, resolves Asana custom field values from a JSON **`custom-field-map`** (path patterns with `*` prefix/suffix/substring rules and optional `"*"` fallback), and updates every Asana task linked in the PR description.
> 
> Shared helpers **`parseCustomFieldsHash`** / **`parseCustomFieldMap`** now validate custom-field JSON for both this action and **`update-task-custom-fields`**; **`findAsanaTasks`** returns an empty list when there is no PR body; errors use **`formatErrorMessage`**. **`action.yml`** gains **`github-pr`** and **`custom-field-map`** inputs; README documents the workflow (e.g. on merge). **`dist/index.js`** is rebuilt; tests cover pattern matching, fallbacks, validation, multi-task updates, and batch abort on API failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e532b87198ace24535f24c01507f5e36302fed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->