### PR TITLE
Allow add-asana-task-id to receive trigger-phrase

### DIFF
--- a/action.js
+++ b/action.js
@@ -172,7 +172,8 @@ async function addTaskToAsanaProject() {
 
     const projectId = core.getInput('asana-project', { required: true });
     const sectionId = core.getInput('asana-section');
-    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const explicitTaskIds = getArrayFromInput(core.getInput('asana-task-id'));
+    const taskIds = explicitTaskIds.length > 0 ? explicitTaskIds : await findAsanaTasks();
 
     if (taskIds.length === 0) {
         core.setFailed(`No valid task IDs provided`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -178,7 +178,8 @@ async function addTaskToAsanaProject() {
 
     const projectId = core.getInput('asana-project', { required: true });
     const sectionId = core.getInput('asana-section');
-    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const explicitTaskIds = getArrayFromInput(core.getInput('asana-task-id'));
+    const taskIds = explicitTaskIds.length > 0 ? explicitTaskIds : await findAsanaTasks();
 
     if (taskIds.length === 0) {
         core.setFailed(`No valid task IDs provided`);

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -509,7 +509,8 @@ describe('GitHub Asana Sync Action', () => {
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should fail if no task IDs are provided', async () => {
+        it('should fail if no task IDs are provided and PR body has no Asana URLs', async () => {
+            github.context.payload.pull_request.body = 'This PR has no Asana links.';
             mockGetInput({
                 action: 'add-task-asana-project',
                 'asana-pat': 'mock-asana-pat',
@@ -521,6 +522,32 @@ describe('GitHub Asana Sync Action', () => {
 
             expect(mockAsanaClient.tasks.addProjectForTask).not.toHaveBeenCalled();
             expect(core.setFailed).toHaveBeenCalledWith('No valid task IDs provided');
+        });
+
+        it('should fall back to PR body tasks when asana-task-id is omitted', async () => {
+            github.context.payload.pull_request.body =
+                'Task/Issue URL: https://app.asana.com/0/1111/2222\nTask/Issue URL: https://app.asana.com/0/1111/3333';
+            mockGetInput({
+                action: 'add-task-asana-project',
+                'asana-pat': 'mock-asana-pat',
+                'asana-project': mockAsanaProject,
+                'trigger-phrase': 'Task/Issue URL:',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.addProjectForTask).toHaveBeenCalledTimes(2);
+            expect(mockAsanaClient.tasks.addProjectForTask).toHaveBeenCalledWith(
+                { data: { insert_after: null, project: mockAsanaProject } },
+                '2222',
+                {},
+            );
+            expect(mockAsanaClient.tasks.addProjectForTask).toHaveBeenCalledWith(
+                { data: { insert_after: null, project: mockAsanaProject } },
+                '3333',
+                {},
+            );
+            expect(core.setFailed).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1211760946270935/task/1215712808891365?focus=true

According to the [README](https://app.asana.com/1/137249556945/project/1211760946270935/task/1215712808891365?focus=true), `trigger-phrase` can be supplied to `add-task-asana-project`. However, it only looks for `asana-task-id`, and will fail if not present. 

This PR adds support for `trigger-phrase`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in a GitHub Action integration path; explicit task IDs are unchanged, and failure modes are preserved when nothing is found.
> 
> **Overview**
> **`add-task-asana-project`** no longer requires **`asana-task-id`**. When that input is empty or omitted, the action resolves task IDs from the PR description using the existing **`trigger-phrase`** + Asana URL logic (same as **`find-asana-task-id`** and related actions).
> 
> Explicit comma-separated **`asana-task-id`** values still take precedence when provided. The workflow still fails with **No valid task IDs provided** if neither explicit IDs nor PR-body matches yield any tasks. **`dist/index.js`** is updated to match **`action.js`**, and tests cover the fallback and the no-links failure case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da341eeb77f735b66d0fa566b0c4a9ddbb28ba95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->