### PR TITLE
Add support for update-task-custom-fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This action integrates asana with github.
 - `send-mattermost-message` to send a message to a channel in Mattermost
 - `get-asana-task-permalink` to get the permalink for a given Asana Task ID
 - `mark-asana-task-complete` to mark an Asana task as complete or incomplete
+- `update-task-custom-fields` to update custom field values on one or more existing Asana tasks
 
 ### Create Asana task from Github Issue
 
@@ -619,6 +620,64 @@ jobs:
                   asana-task-id: ${{ github.event.inputs.task_id }}
                   is-complete: ${{ github.event.inputs.complete }}
                   action: 'mark-asana-task-complete'
+```
+
+### Update custom fields on an Asana task
+
+Updates custom field values on one or more existing Asana tasks. Useful when a task should be tagged with metadata (release status, team, objective, etc.) after it's created or moved between projects.
+
+### `asana-pat`
+
+**Required** Asana public access token
+
+### `asana-task-id`
+
+**Required** ID of the Asana task to update. Can be a single ID or a comma-separated list of IDs — the same custom-field payload is applied to each task.
+
+### `asana-task-custom-fields`
+
+**Required** Custom field values, encoded as a JSON object string. The value must be a JSON **object** (hash) keyed by custom-field GID — this matches Asana's write format for `custom_fields` on the [update task endpoint](https://developers.asana.com/reference/updatetask). Asana's GET shape (the "array of objects" returned when reading a task) is _not_ accepted on writes.
+
+The per-type value is:
+
+- `enum` → the option GID (string)
+- `multi_enum` → an array of option GIDs
+- `text` → string
+- `number` → number
+- `people` → an array of user GIDs
+
+Example payload combining several types:
+
+```json
+{
+    "1214395894874538": "1214395894874539",
+    "1210006359830485": ["1210006359830486", "1210006359830487"],
+    "1206366040248299": 3,
+    "1202953247086041": ["12345"]
+}
+```
+
+> Note: you can retrieve custom-field GIDs and their enum option GIDs for a given project via the Asana API, i.e. `https://app.asana.com/api/1.0/projects/<project_gid>/custom_field_settings`.
+
+If the JSON fails to parse, the action fails and no tasks are updated.
+
+#### Example Usage
+
+```yaml
+on:
+    workflow_dispatch:
+
+jobs:
+    update-fields:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Update custom fields on Asana task
+              uses: duckduckgo/native-github-asana-sync@v1.1
+              with:
+                  asana-pat: ${{ secrets.asana_pat }}
+                  asana-task-id: '1212699261164265'
+                  asana-task-custom-fields: '{"1214395894874538":"1214395894874539"}'
+                  action: 'update-task-custom-fields'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -661,6 +661,8 @@ Example payload combining several types:
 
 If the JSON fails to parse, the action fails and no tasks are updated.
 
+When multiple task IDs are provided and the Asana API rejects one update mid-batch, the action stops on the first failure: tasks earlier in the list keep the new values, the failing task and all subsequent tasks are left untouched, and `setFailed` reports which IDs were skipped. Asana has no batch rollback, so re-running the action after fixing the root cause is the way to land a uniform update.
+
 #### Example Usage
 
 ```yaml

--- a/action.js
+++ b/action.js
@@ -185,6 +185,40 @@ async function addTaskToAsanaProject() {
     }
 }
 
+async function updateTaskCustomFieldsAction() {
+    const client = buildAsanaClient();
+
+    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const customFieldsInput = core.getInput('asana-task-custom-fields', { required: true });
+
+    if (taskIds.length === 0) {
+        core.setFailed(`No valid task IDs provided`);
+        return;
+    }
+
+    let customFields;
+    try {
+        customFields = JSON.parse(customFieldsInput);
+    } catch (error) {
+        core.setFailed(`Invalid custom fields JSON: ${customFieldsInput}`);
+        return;
+    }
+
+    for (const taskId of taskIds) {
+        await updateTaskCustomFields(client, taskId, customFields);
+    }
+}
+
+async function updateTaskCustomFields(client, taskId, customFields) {
+    console.info(`Updating custom fields on task ${taskId}`);
+    try {
+        await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
+    } catch (error) {
+        console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}`);
+    }
+}
+
 async function addTaskToProject(client, taskId, projectId, sectionId) {
     if (!sectionId) {
         console.info('adding asana task to project', projectId);
@@ -658,6 +692,10 @@ async function action() {
         }
         case 'mark-asana-task-complete': {
             await markAsanaTaskComplete();
+            break;
+        }
+        case 'update-task-custom-fields': {
+            await updateTaskCustomFieldsAction();
             break;
         }
         default:

--- a/action.js
+++ b/action.js
@@ -204,19 +204,23 @@ async function updateTaskCustomFieldsAction() {
         return;
     }
 
-    for (const taskId of taskIds) {
-        await updateTaskCustomFields(client, taskId, customFields);
+    for (let i = 0; i < taskIds.length; i++) {
+        const taskId = taskIds[i];
+        try {
+            await updateTaskCustomFields(client, taskId, customFields);
+        } catch (error) {
+            console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
+            const remaining = taskIds.slice(i + 1);
+            const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
+            core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}.${suffix}`);
+            return;
+        }
     }
 }
 
 async function updateTaskCustomFields(client, taskId, customFields) {
     console.info(`Updating custom fields on task ${taskId}`);
-    try {
-        await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
-    } catch (error) {
-        console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
-        core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}`);
-    }
+    await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
 }
 
 async function addTaskToProject(client, taskId, projectId, sectionId) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -210,19 +210,23 @@ async function updateTaskCustomFieldsAction() {
         return;
     }
 
-    for (const taskId of taskIds) {
-        await updateTaskCustomFields(client, taskId, customFields);
+    for (let i = 0; i < taskIds.length; i++) {
+        const taskId = taskIds[i];
+        try {
+            await updateTaskCustomFields(client, taskId, customFields);
+        } catch (error) {
+            console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
+            const remaining = taskIds.slice(i + 1);
+            const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
+            core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}.${suffix}`);
+            return;
+        }
     }
 }
 
 async function updateTaskCustomFields(client, taskId, customFields) {
     console.info(`Updating custom fields on task ${taskId}`);
-    try {
-        await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
-    } catch (error) {
-        console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
-        core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}`);
-    }
+    await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
 }
 
 async function addTaskToProject(client, taskId, projectId, sectionId) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -191,6 +191,40 @@ async function addTaskToAsanaProject() {
     }
 }
 
+async function updateTaskCustomFieldsAction() {
+    const client = buildAsanaClient();
+
+    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const customFieldsInput = core.getInput('asana-task-custom-fields', { required: true });
+
+    if (taskIds.length === 0) {
+        core.setFailed(`No valid task IDs provided`);
+        return;
+    }
+
+    let customFields;
+    try {
+        customFields = JSON.parse(customFieldsInput);
+    } catch (error) {
+        core.setFailed(`Invalid custom fields JSON: ${customFieldsInput}`);
+        return;
+    }
+
+    for (const taskId of taskIds) {
+        await updateTaskCustomFields(client, taskId, customFields);
+    }
+}
+
+async function updateTaskCustomFields(client, taskId, customFields) {
+    console.info(`Updating custom fields on task ${taskId}`);
+    try {
+        await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
+    } catch (error) {
+        console.error(`Error updating custom fields on task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Error updating custom fields on task ${taskId}: ${error.message}`);
+    }
+}
+
 async function addTaskToProject(client, taskId, projectId, sectionId) {
     if (!sectionId) {
         console.info('adding asana task to project', projectId);
@@ -664,6 +698,10 @@ async function action() {
         }
         case 'mark-asana-task-complete': {
             await markAsanaTaskComplete();
+            break;
+        }
+        case 'update-task-custom-fields': {
+            await updateTaskCustomFieldsAction();
             break;
         }
         default:

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -578,6 +578,28 @@ describe('GitHub Asana Sync Action', () => {
             expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
             expect(core.setFailed).toHaveBeenCalledWith('No valid task IDs provided');
         });
+
+        it('should abort the batch on first API failure and skip remaining tasks', async () => {
+            mockGetInput({
+                action: 'update-task-custom-fields',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': 'task-abc, task-def, task-ghi',
+                'asana-task-custom-fields': '{"1234567890":"option-gid"}',
+            });
+            mockAsanaClient.tasks.updateTask
+                .mockImplementationOnce(() => Promise.resolve({}))
+                .mockImplementationOnce(() => Promise.reject(new Error('boom')));
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(2);
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(expect.anything(), 'task-abc', {});
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(expect.anything(), 'task-def', {});
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalledWith(expect.anything(), 'task-ghi', {});
+            expect(core.setFailed).toHaveBeenCalledWith(
+                'Error updating custom fields on task task-def: boom. Skipped remaining tasks: task-ghi.',
+            );
+        });
     });
 
     describe('action: create-asana-pr-task', () => {

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -524,6 +524,62 @@ describe('GitHub Asana Sync Action', () => {
         });
     });
 
+    describe('action: update-task-custom-fields', () => {
+        const taskIdsToUpdate = 'task-abc, task-def';
+
+        it('should update custom fields on each task', async () => {
+            mockGetInput({
+                action: 'update-task-custom-fields',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': taskIdsToUpdate,
+                'asana-task-custom-fields': '{"1234567890":"option-gid"}',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(2);
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
+                { data: { custom_fields: { 1234567890: 'option-gid' } } },
+                'task-abc',
+                {},
+            );
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
+                { data: { custom_fields: { 1234567890: 'option-gid' } } },
+                'task-def',
+                {},
+            );
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should fail when JSON is invalid', async () => {
+            mockGetInput({
+                action: 'update-task-custom-fields',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': taskIdsToUpdate,
+                'asana-task-custom-fields': 'not-json',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('Invalid custom fields JSON: not-json');
+        });
+
+        it('should fail when no task IDs are provided', async () => {
+            mockGetInput({
+                action: 'update-task-custom-fields',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': ',',
+                'asana-task-custom-fields': '{"1234567890":"option-gid"}',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('No valid task IDs provided');
+        });
+    });
+
     describe('action: create-asana-pr-task', () => {
         it('should create an Asana task from a GitHub PR', async () => {
             mockGetInput({


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1211760946270935/task/1215712808891366?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive action with isolated code path and tests; main operational risk is partial updates when multi-task batches fail mid-run, which is documented.
> 
> **Overview**
> Adds a new **`update-task-custom-fields`** action so workflows can set custom field metadata on **existing** Asana tasks (single ID or comma-separated list), using the same **`asana-task-custom-fields`** JSON object format as task creation.
> 
> Implementation parses the JSON, calls Asana **`tasks.updateTask`** with `custom_fields` for each task, and **stops on the first API error**—earlier tasks keep updates; the failure message lists skipped IDs. Invalid JSON or empty task IDs fail without calling Asana.
> 
> README documents inputs, field-type shapes, partial-batch behavior, and an example workflow. **`dist/index.js`** is rebuilt; tests cover happy path, validation, and batch abort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86af3f92da6b395908b3f001f7287b876632d3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->