### PR TITLE
Release v2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@duckduckgo/native-github-asana-sync",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@duckduckgo/native-github-asana-sync",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "ISC",
             "dependencies": {
                 "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duckduckgo/native-github-asana-sync",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary
- Bump `package.json` / `package-lock.json` to **2.5.0** for the release after #35, #36, and #37 merged to `main`
- Verified on this branch: `npm run lint`, `npm test` (64 tests), `npm run build`, and `git diff --exit-code` all pass — `dist/index.js` is in sync

## Release notes (for `gh release create v2.5` after merge)

## What's Changed

- Add `set-asana-custom-fields-from-diff` action to set Asana custom fields based on PR file changes by @laghee in #35
- Add `update-task-custom-fields` action to update custom fields on existing tasks by @CrisBarreiro in #37
- Allow `add-task-asana-project` to discover tasks from PR body via `trigger-phrase` when `asana-task-id` is omitted by @CrisBarreiro in #36

Full Changelog: https://github.com/duckduckgo/native-github-asana-sync/compare/v2.4...v2.5

## Test plan
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --exit-code` (dist committed and matches build)

Made with [Cursor](https://cursor.com)