### PR TITLE
Add build-mention-comment mode and @-mention forwarding

### DIFF
--- a/.github/actions/pr-review-notifications/action.yml
+++ b/.github/actions/pr-review-notifications/action.yml
@@ -9,6 +9,15 @@ inputs:
         type: string
     asana_pat:
         required: true
+    user-map:
+        description: >-
+            Optional JSON map of GitHub logins to Asana user GIDs. When set,
+            a PR review comment that @-mentions a mapped user is forwarded to
+            the linked Asana task as a real Asana @-mention. When empty
+            (default) this forwarding is skipped and only the canned
+            approved/changes-requested/dismissed notes are posted.
+        required: false
+        default: '{}'
 
 runs:
     using: 'composite'
@@ -51,4 +60,29 @@ runs:
               asana-pat: ${{ inputs.asana_pat }}
               asana-task-id: ${{ steps.find-asana-task-id.outputs.asanaTaskId }}
               asana-task-comment: 'PR: ${{ github.event.pull_request.html_url }} review has been dismissed.'
+              asana-task-comment-pinned: false
+
+        # Gate on @-mentions of users in user-map and build the @-mention comment.
+        # Works for both review summaries and inline review comments.
+        # `!cancelled()` so mention forwarding runs regardless of whether the
+        # canned approved/changes-requested/dismissed steps ran or failed —
+        # it does not depend on them.
+        - name: Build @-mention comment
+          if: ${{ !cancelled() }}
+          uses: ./native-github-asana-sync
+          id: build-mention-comment
+          with:
+              action: 'build-mention-comment'
+              user-map: ${{ inputs.user-map }}
+
+        - name: Post @-mention comment to Asana Task
+          if: ${{ !cancelled() && steps.build-mention-comment.outputs.shouldPost == 'true' && steps.find-asana-task-id.outputs.asanaTaskId != '' }}
+          uses: ./native-github-asana-sync
+          id: post-comment-pr-mention
+          with:
+              action: 'post-comment-asana-task'
+              asana-pat: ${{ inputs.asana_pat }}
+              asana-task-id: ${{ steps.find-asana-task-id.outputs.asanaTaskId }}
+              asana-task-comment: ${{ steps.build-mention-comment.outputs.mentionComment }}
+              asana-task-comment-is-html: true
               asana-task-comment-pinned: false

--- a/README.md
+++ b/README.md
@@ -506,6 +506,61 @@ jobs:
                   asana-task-comment-is-html: true
 ```
 
+### Build @-mention comment
+
+Inspects the triggering PR review or comment and, when it `@`-mentions a GitHub user present in `user-map`, builds an Asana HTML comment that `@`-mentions the corresponding Asana user (via `data-asana-gid`). Supports the `pull_request_review`, `pull_request_review_comment` and `issue_comment` events — the comment text and link are read from the event payload automatically.
+
+It does not post anything itself; pair it with `find-asana-task-id` and `post-comment-asana-task` (with `asana-task-comment-is-html: true`).
+
+### `user-map`
+
+**Required** JSON string mapping GitHub logins to Asana user GIDs, e.g. `{"octocat":"1201234567890"}`. Only `@`-mentions of logins present in this map are forwarded; an empty map, a non-object value (`null`, array) or invalid JSON results in a warning and no output (it never fails the step).
+
+#### Outputs
+
+- `shouldPost` — set to `'true'` only when at least one mapped user was `@`-mentioned (unset otherwise).
+- `mentionComment` — the HTML `html_text` body to post, when `shouldPost` is `'true'`.
+
+#### Example Usage
+
+```yaml
+on:
+    pull_request_review:
+        types: [submitted]
+    pull_request_review_comment:
+        types: [created]
+    issue_comment:
+        types: [created]
+
+jobs:
+    test-job:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Find Asana task
+              uses: ./actions
+              id: find-asana-task-id
+              with:
+                  action: 'find-asana-task-id'
+                  trigger-phrase: 'Task/Issue URL:'
+
+            - name: Build @-mention comment
+              uses: ./actions
+              id: build-mention-comment
+              with:
+                  action: 'build-mention-comment'
+                  user-map: ${{ vars.GH_USER_MAP }}
+
+            - name: Post @-mention comment
+              if: ${{ !cancelled() && steps.build-mention-comment.outputs.shouldPost == 'true' && steps.find-asana-task-id.outputs.asanaTaskId != '' }}
+              uses: ./actions
+              with:
+                  action: 'post-comment-asana-task'
+                  asana-pat: ${{ secrets.asana_pat }}
+                  asana-task-id: ${{ steps.find-asana-task-id.outputs.asanaTaskId }}
+                  asana-task-comment: ${{ steps.build-mention-comment.outputs.mentionComment }}
+                  asana-task-comment-is-html: true
+```
+
 ### Send a message in Mattermost
 
 Sends a message to Mattermost

--- a/action.js
+++ b/action.js
@@ -108,8 +108,10 @@ async function isTaskInProject(taskId, projectId) {
 
 async function findAsanaTasks() {
     const triggerPhrase = core.getInput('trigger-phrase');
-    const pullRequest = github.context.payload.pull_request;
-    if (!pullRequest?.body) {
+    // pull_request is present on PR / review / review_comment events; on
+    // issue_comment events the PR description is on issue.body instead.
+    const prBody = github.context.payload.pull_request?.body ?? github.context.payload.issue?.body;
+    if (!prBody) {
         console.info('No pull request context available for task discovery');
         return [];
     }
@@ -117,10 +119,10 @@ async function findAsanaTasks() {
     const specifiedProjectId = core.getInput('asana-project');
     const regex = new RegExp(regexString, 'g');
 
-    console.info('Looking for asana task link in body:\n', pullRequest.body, 'regex:\n', regexString);
+    console.info('Looking for asana task link in body:\n', prBody, 'regex:\n', regexString);
     const foundTasks = [];
     let parseAsanaUrl;
-    while ((parseAsanaUrl = regex.exec(pullRequest.body)) !== null) {
+    while ((parseAsanaUrl = regex.exec(prBody)) !== null) {
         const taskId = parseAsanaUrl.groups.task;
         const projectId = parseAsanaUrl.groups.project;
 
@@ -860,6 +862,10 @@ async function action() {
             await postCommentAsanaTask();
             break;
         }
+        case 'build-mention-comment': {
+            await buildMentionComment();
+            break;
+        }
         case 'send-mattermost-message': {
             await sendMattermostMessage();
             break;
@@ -879,6 +885,76 @@ async function action() {
         default:
             core.setFailed(`unexpected action ${action}`);
     }
+}
+
+// Gate a PR review comment on @-mentions of users in `user-map`, and, when a
+// mapped user is tagged, build an Asana HTML comment that @-mentions them.
+// Reads the comment text from the review (pull_request_review) or inline
+// comment (pull_request_review_comment) event payload. Sets two outputs:
+//   shouldPost     - 'true' only when a mapped user was @-mentioned
+//   mentionComment - the html_text body to post (when shouldPost is 'true')
+async function buildMentionComment() {
+    const eventName = github.context.eventName;
+    const payload = github.context.payload;
+
+    let body, permalink;
+    if (eventName === 'pull_request_review') {
+        body = payload.review?.body || '';
+        permalink = payload.review?.html_url;
+    } else if (eventName === 'pull_request_review_comment' || eventName === 'issue_comment') {
+        // Inline code comment, or a top-level PR conversation comment.
+        body = payload.comment?.body || '';
+        permalink = payload.comment?.html_url;
+    } else {
+        console.info(`Unsupported event ${eventName}; skipping mention sync.`);
+        return;
+    }
+
+    if (!body.trim()) {
+        console.info('Empty comment body; nothing to forward.');
+        return;
+    }
+
+    let map = {};
+    try {
+        const parsed = JSON.parse(core.getInput('user-map') || '{}');
+        // Accept only a plain object; null, arrays and primitives are valid JSON
+        // but would either crash Object.entries (null) or iterate nonsense.
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            map = parsed;
+        } else {
+            core.warning('user-map is not a JSON object; ignoring.');
+        }
+    } catch (e) {
+        core.warning(`Could not parse user-map: ${e}`);
+    }
+    const mapLower = {};
+    for (const [login, gid] of Object.entries(map)) {
+        mapLower[login.toLowerCase()] = gid;
+    }
+
+    // Collect @-mentions; the leading boundary avoids matching email local-parts.
+    const mentioned = new Set();
+    const re = /(^|[^A-Za-z0-9_@/])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))/g;
+    let m;
+    while ((m = re.exec(body)) !== null) {
+        mentioned.add(m[2].toLowerCase());
+    }
+    const tagged = [...mentioned].filter((login) => mapLower[login]);
+
+    if (tagged.length === 0) {
+        console.info('No mapped user @-mentioned; skipping mention sync.');
+        return;
+    }
+
+    // Escape the URL so it can't break Asana's HTML parser.
+    const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const mentionsHtml = tagged.map((login) => `<a data-asana-gid="${mapLower[login]}"/>`).join(' ');
+    const mentions = `<body>${mentionsHtml} has been mentioned in PR <a href="${esc(permalink)}">${esc(permalink)}</a></body>`;
+
+    core.setOutput('shouldPost', 'true');
+    core.setOutput('mentionComment', mentions);
+    console.info(`Mapped users tagged: ${tagged.join(', ')}`);
 }
 
 module.exports = {

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,9 @@ inputs:
     trigger-phrase:
         description: 'Prefix used to identify Asana tasks (URL). If not provided, any Asana URL in the text will be matched.'
         required: false
+    user-map:
+        description: 'JSON map of GitHub logins to Asana user GIDs, used by build-mention-comment to gate and render @-mentions. Optional; defaults to an empty map.'
+        required: false
     is-complete:
         description: 'Set to true to mark the task(s) as complete, false to mark as incomplete. Defaults to false if not provided. [true | false].'
         required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -114,8 +114,10 @@ async function isTaskInProject(taskId, projectId) {
 
 async function findAsanaTasks() {
     const triggerPhrase = core.getInput('trigger-phrase');
-    const pullRequest = github.context.payload.pull_request;
-    if (!pullRequest?.body) {
+    // pull_request is present on PR / review / review_comment events; on
+    // issue_comment events the PR description is on issue.body instead.
+    const prBody = github.context.payload.pull_request?.body ?? github.context.payload.issue?.body;
+    if (!prBody) {
         console.info('No pull request context available for task discovery');
         return [];
     }
@@ -123,10 +125,10 @@ async function findAsanaTasks() {
     const specifiedProjectId = core.getInput('asana-project');
     const regex = new RegExp(regexString, 'g');
 
-    console.info('Looking for asana task link in body:\n', pullRequest.body, 'regex:\n', regexString);
+    console.info('Looking for asana task link in body:\n', prBody, 'regex:\n', regexString);
     const foundTasks = [];
     let parseAsanaUrl;
-    while ((parseAsanaUrl = regex.exec(pullRequest.body)) !== null) {
+    while ((parseAsanaUrl = regex.exec(prBody)) !== null) {
         const taskId = parseAsanaUrl.groups.task;
         const projectId = parseAsanaUrl.groups.project;
 
@@ -866,6 +868,10 @@ async function action() {
             await postCommentAsanaTask();
             break;
         }
+        case 'build-mention-comment': {
+            await buildMentionComment();
+            break;
+        }
         case 'send-mattermost-message': {
             await sendMattermostMessage();
             break;
@@ -885,6 +891,76 @@ async function action() {
         default:
             core.setFailed(`unexpected action ${action}`);
     }
+}
+
+// Gate a PR review comment on @-mentions of users in `user-map`, and, when a
+// mapped user is tagged, build an Asana HTML comment that @-mentions them.
+// Reads the comment text from the review (pull_request_review) or inline
+// comment (pull_request_review_comment) event payload. Sets two outputs:
+//   shouldPost     - 'true' only when a mapped user was @-mentioned
+//   mentionComment - the html_text body to post (when shouldPost is 'true')
+async function buildMentionComment() {
+    const eventName = github.context.eventName;
+    const payload = github.context.payload;
+
+    let body, permalink;
+    if (eventName === 'pull_request_review') {
+        body = payload.review?.body || '';
+        permalink = payload.review?.html_url;
+    } else if (eventName === 'pull_request_review_comment' || eventName === 'issue_comment') {
+        // Inline code comment, or a top-level PR conversation comment.
+        body = payload.comment?.body || '';
+        permalink = payload.comment?.html_url;
+    } else {
+        console.info(`Unsupported event ${eventName}; skipping mention sync.`);
+        return;
+    }
+
+    if (!body.trim()) {
+        console.info('Empty comment body; nothing to forward.');
+        return;
+    }
+
+    let map = {};
+    try {
+        const parsed = JSON.parse(core.getInput('user-map') || '{}');
+        // Accept only a plain object; null, arrays and primitives are valid JSON
+        // but would either crash Object.entries (null) or iterate nonsense.
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            map = parsed;
+        } else {
+            core.warning('user-map is not a JSON object; ignoring.');
+        }
+    } catch (e) {
+        core.warning(`Could not parse user-map: ${e}`);
+    }
+    const mapLower = {};
+    for (const [login, gid] of Object.entries(map)) {
+        mapLower[login.toLowerCase()] = gid;
+    }
+
+    // Collect @-mentions; the leading boundary avoids matching email local-parts.
+    const mentioned = new Set();
+    const re = /(^|[^A-Za-z0-9_@/])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))/g;
+    let m;
+    while ((m = re.exec(body)) !== null) {
+        mentioned.add(m[2].toLowerCase());
+    }
+    const tagged = [...mentioned].filter((login) => mapLower[login]);
+
+    if (tagged.length === 0) {
+        console.info('No mapped user @-mentioned; skipping mention sync.');
+        return;
+    }
+
+    // Escape the URL so it can't break Asana's HTML parser.
+    const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const mentionsHtml = tagged.map((login) => `<a data-asana-gid="${mapLower[login]}"/>`).join(' ');
+    const mentions = `<body>${mentionsHtml} has been mentioned in PR <a href="${esc(permalink)}">${esc(permalink)}</a></body>`;
+
+    core.setOutput('shouldPost', 'true');
+    core.setOutput('mentionComment', mentions);
+    console.info(`Mapped users tagged: ${tagged.join(', ')}`);
 }
 
 module.exports = {

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -82,6 +82,7 @@ jest.mock('@actions/core', () => ({
     getInput: jest.fn(),
     setOutput: jest.fn(),
     setFailed: jest.fn(),
+    warning: jest.fn(),
 }));
 
 // Mock @actions/github
@@ -1103,6 +1104,119 @@ describe('GitHub Asana Sync Action', () => {
             expect(mockAsanaClient.tasks.getTask).toHaveBeenCalledTimes(2);
             expect(core.setOutput).toHaveBeenCalledWith('asanaTaskId', '3333'); // Should return first valid task
             expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should find the task from issue.body on issue_comment events', async () => {
+            mockGetInput({
+                action: 'find-asana-task-id',
+                'trigger-phrase': 'Closes',
+            });
+            // issue_comment payloads have no pull_request; the PR description
+            // is on issue.body instead.
+            github.context.payload.pull_request = undefined;
+            github.context.payload.issue = {
+                body: 'This PR fixes bugs.\n\nCloses https://app.asana.com/0/1111/2222',
+            };
+
+            await action();
+
+            expect(core.setOutput).toHaveBeenCalledWith('asanaTaskId', '2222');
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('action: build-mention-comment', () => {
+        function reviewPayload(body) {
+            return {
+                review: { body, html_url: 'https://github.com/o/r/pull/1#pullrequestreview-9' },
+                pull_request: { number: 1, html_url: 'https://github.com/o/r/pull/1' },
+            };
+        }
+
+        it('emits shouldPost and an @-mention comment when a mapped user is tagged', async () => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': '{"alice":"111"}' });
+            github.context.eventName = 'pull_request_review';
+            github.context.payload = reviewPayload('LGTM @Alice');
+
+            await action();
+
+            expect(core.setOutput).toHaveBeenCalledWith('shouldPost', 'true');
+            expect(core.setOutput).toHaveBeenCalledWith('mentionComment', expect.stringContaining('<a data-asana-gid="111"/>'));
+            expect(core.setOutput).toHaveBeenCalledWith('mentionComment', expect.stringContaining('has been mentioned in PR'));
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('does nothing when the mentioned user is not in the map', async () => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': '{"alice":"111"}' });
+            github.context.eventName = 'pull_request_review';
+            github.context.payload = reviewPayload('cc @bob');
+
+            await action();
+
+            expect(core.setOutput).not.toHaveBeenCalled();
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('does nothing on an empty comment body', async () => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': '{"alice":"111"}' });
+            github.context.eventName = 'pull_request_review';
+            github.context.payload = reviewPayload('   ');
+
+            await action();
+
+            expect(core.setOutput).not.toHaveBeenCalled();
+        });
+
+        it('does nothing with an empty user-map', async () => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': '{}' });
+            github.context.eventName = 'pull_request_review';
+            github.context.payload = reviewPayload('LGTM @Alice');
+
+            await action();
+
+            expect(core.setOutput).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            ['null', 'null'],
+            ['an array', '[1,2]'],
+            ['unparseable JSON', 'not json'],
+        ])('warns and does not crash when user-map is %s', async (_label, value) => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': value });
+            github.context.eventName = 'pull_request_review';
+            github.context.payload = reviewPayload('LGTM @Alice');
+
+            await action();
+
+            expect(core.warning).toHaveBeenCalled();
+            expect(core.setOutput).not.toHaveBeenCalled();
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('handles inline review comments (pull_request_review_comment)', async () => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': '{"alice":"111"}' });
+            github.context.eventName = 'pull_request_review_comment';
+            github.context.payload = {
+                comment: { body: 'nit @Alice', html_url: 'https://github.com/o/r/pull/1#discussion_r1' },
+                pull_request: { number: 1, html_url: 'https://github.com/o/r/pull/1' },
+            };
+
+            await action();
+
+            expect(core.setOutput).toHaveBeenCalledWith('shouldPost', 'true');
+        });
+
+        it('handles top-level PR comments (issue_comment)', async () => {
+            mockGetInput({ action: 'build-mention-comment', 'user-map': '{"alice":"111"}' });
+            github.context.eventName = 'issue_comment';
+            github.context.payload = {
+                comment: { body: 'hey @Alice', html_url: 'https://github.com/o/r/pull/1#issuecomment-1' },
+                issue: { number: 1, pull_request: { url: 'https://api.github.com/repos/o/r/pulls/1' } },
+            };
+
+            await action();
+
+            expect(core.setOutput).toHaveBeenCalledWith('shouldPost', 'true');
         });
     });
 


### PR DESCRIPTION
Add a `build-mention-comment` action mode that gates a PR review or inline comment on @-mentions of users present in a supplied user-map, and builds an Asana html_text comment that @-mentions them via data-asana-gid. Wire it into the pr-review-notifications composite behind a new optional `user-map` input (default empty = no-op), so review summaries and inline comments that tag a mapped user are forwarded to the linked Asana task. Rebuild dist.

Task: https://app.asana.com/1/137249556945/project/1212608036467427/task/1215911521920630?focus=true

Testing: locally using `act`

Corresponding Android repo change pending on this PR landing: https://github.com/duckduckgo/Android/pull/8954/changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional, default-off behavior with defensive JSON handling; only posts to Asana when a mapped mention is detected and a task ID exists.
> 
> **Overview**
> Adds a **`build-mention-comment`** action mode that scans PR review text, inline review comments, and top-level PR **`issue_comment`** bodies for GitHub `@`-mentions, matches them against an optional **`user-map`** (GitHub login → Asana user GID), and outputs HTML for real Asana mentions via `data-asana-gid`. Invalid or empty maps warn and no-op without failing the step.
> 
> The **`pr-review-notifications`** composite gains an optional **`user-map`** input (default `{}`) and two steps—build then post with **`asana-task-comment-is-html: true`**—gated with **`!cancelled()`** so mention forwarding is independent of the approved/changes-requested/dismissed comment steps.
> 
> **`find-asana-task-id`** task discovery now reads **`issue.body`** when **`pull_request.body`** is missing, so linked tasks can be resolved on **`issue_comment`** events. README documents the new mode; **`dist/index.js`** is rebuilt; tests cover mention building, map edge cases, and **`issue_comment`** task lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82cda58fe924eb88804118adbd8bb1d45afeb60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->