### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@duckduckgo/native-github-asana-sync",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@duckduckgo/native-github-asana-sync",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "license": "ISC",
             "dependencies": {
                 "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duckduckgo/native-github-asana-sync",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Aligns package.json/package-lock with the upcoming **v2.6.0** release.

## What's in v2.6.0
- build-mention-comment mode, @-mention forwarding, and Asana task API error-handling fixes (already on `main`)
- Node 24 runtime and notify-release hardening ([#39](https://github.com/duckduckgo/native-github-asana-sync/pull/39))

## Release plan
1. Merge [#39](https://github.com/duckduckgo/native-github-asana-sync/pull/39) and this PR
2. Publish GitHub release **v2.6.0** from `main`
3. Downstream workflows pin `duckduckgo/native-github-asana-sync@v2.6.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or dependency changes—only the package version fields are updated.
> 
> **Overview**
> Bumps **`@duckduckgo/native-github-asana-sync`** from **2.5.0** to **2.6.0** in `package.json` and the root entry in `package-lock.json` so the published package version matches the v2.6 release.
> 
> This is a metadata-only change; behavior shipped in v2.6 (e.g. build-mention-comment mode, @-mention forwarding, Asana task API error-handling fixes) is already merged and is not modified by this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bee501ea50476fa44394bc4650b62d7d99e8ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->