### PR TITLE
Support new privacy triage task lifecycle

### DIFF
--- a/.github/actions/privacy-review/action.yml
+++ b/.github/actions/privacy-review/action.yml
@@ -99,6 +99,7 @@ runs:
           env:
               PR_URL: ${{ github.event.pull_request.html_url }}
               TRIAGE_TASK_ID: ${{ steps.create-review-task.outputs.taskId }}
+              TEAM_NAME: ${{ inputs.team_name }}
           with:
               github-token: ${{ inputs.github_pat }}
               script: |
@@ -110,6 +111,7 @@ runs:
                     inputs: {
                       pr_url: process.env.PR_URL,
                       privacy_triage_task_id: process.env.TRIAGE_TASK_ID,
+                      team_name: process.env.TEAM_NAME,
                     },
                   });
 

--- a/.github/actions/privacy-review/action.yml
+++ b/.github/actions/privacy-review/action.yml
@@ -58,6 +58,15 @@ runs:
               asana-task-custom-fields: '{"1211720829744228":"1211720829744237"}' # Category:Pixels
               action: 'create-asana-task'
 
+        - name: Set Privacy Review task type and In progress status
+          uses: ./native-github-asana-sync
+          with:
+              asana-pat: ${{ inputs.asana_pat }}
+              asana-task-id: ${{ steps.create-review-task.outputs.taskId }}
+              asana-task-custom-type: '1216331193579792' # gitleaks:allow - public Asana custom type GID
+              asana-task-custom-type-status-option: '1216331193579786'
+              action: 'update-asana-task-type-status'
+
         - name: Add Privacy Review task to PR
           uses: actions/github-script@v7
           with:
@@ -103,3 +112,12 @@ runs:
                       privacy_triage_task_id: process.env.TRIAGE_TASK_ID,
                     },
                   });
+
+        - name: Set Privacy Review task Waiting for AI review status
+          if: ${{ steps.create-review-task.outputs.taskId != '' }}
+          uses: ./native-github-asana-sync
+          with:
+              asana-pat: ${{ inputs.asana_pat }}
+              asana-task-id: ${{ steps.create-review-task.outputs.taskId }}
+              asana-task-custom-type-status-option: '1216371081960403'
+              action: 'update-asana-task-type-status'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This action integrates asana with github.
 - `get-asana-task-permalink` to get the permalink for a given Asana Task ID
 - `mark-asana-task-complete` to mark an Asana task as complete or incomplete
 - `update-task-custom-fields` to update custom field values on one or more existing Asana tasks
+- `update-asana-task-type-status` to apply an Asana custom task type and/or type status to existing tasks
 - `set-asana-custom-fields-from-diff` to set Asana custom field values on the PR's linked task(s) based on the files changed in the PR
 
 ### Create Asana task from Github Issue

--- a/action.js
+++ b/action.js
@@ -295,6 +295,45 @@ async function updateTaskCustomFields(client, taskId, customFields) {
     await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
 }
 
+async function updateAsanaTaskTypeStatusAction() {
+    const client = buildAsanaClient();
+    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const customType = core.getInput('asana-task-custom-type');
+    const customTypeStatusOption = core.getInput('asana-task-custom-type-status-option');
+
+    if (taskIds.length === 0) {
+        core.setFailed('No valid task IDs provided');
+        return;
+    }
+
+    if (!customType && !customTypeStatusOption) {
+        core.setFailed('At least one of asana-task-custom-type or asana-task-custom-type-status-option is required');
+        return;
+    }
+
+    const data = customType
+        ? {
+              resource_subtype: 'custom',
+              custom_type: customType,
+              ...(customTypeStatusOption && { custom_type_status_option: customTypeStatusOption }),
+          }
+        : { custom_type_status_option: customTypeStatusOption };
+
+    for (let i = 0; i < taskIds.length; i++) {
+        const taskId = taskIds[i];
+        try {
+            console.info(`Updating custom type/status on task ${taskId}`);
+            await client.tasks.updateTask({ data }, taskId, {});
+        } catch (error) {
+            console.error(`Error updating custom type/status on task ${taskId}:`, JSON.stringify(error));
+            const remaining = taskIds.slice(i + 1);
+            const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
+            core.setFailed(`Error updating custom type/status on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
+            return;
+        }
+    }
+}
+
 async function addTaskToProject(client, taskId, projectId, sectionId) {
     if (!sectionId) {
         console.info('adding asana task to project', projectId);
@@ -933,6 +972,10 @@ async function action() {
         }
         case 'update-task-custom-fields': {
             await updateTaskCustomFieldsAction();
+            break;
+        }
+        case 'update-asana-task-type-status': {
+            await updateAsanaTaskTypeStatusAction();
             break;
         }
         default:

--- a/action.js
+++ b/action.js
@@ -297,17 +297,17 @@ async function updateTaskCustomFields(client, taskId, customFields) {
 
 async function updateAsanaTaskTypeStatusAction() {
     const client = buildAsanaClient();
-    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const taskId = core.getInput('asana-task-id', { required: true }).trim();
     const customType = core.getInput('asana-task-custom-type');
     const customTypeStatusOption = core.getInput('asana-task-custom-type-status-option');
 
-    if (taskIds.length === 0) {
-        core.setFailed('No valid task IDs provided');
+    if (!taskId) {
+        core.setFailed('No valid task ID provided');
         return;
     }
 
-    if (!customType && !customTypeStatusOption) {
-        core.setFailed('At least one of asana-task-custom-type or asana-task-custom-type-status-option is required');
+    if (!customTypeStatusOption) {
+        core.setFailed('asana-task-custom-type-status-option is required');
         return;
     }
 
@@ -315,22 +315,16 @@ async function updateAsanaTaskTypeStatusAction() {
         ? {
               resource_subtype: 'custom',
               custom_type: customType,
-              ...(customTypeStatusOption && { custom_type_status_option: customTypeStatusOption }),
+              custom_type_status_option: customTypeStatusOption,
           }
         : { custom_type_status_option: customTypeStatusOption };
 
-    for (let i = 0; i < taskIds.length; i++) {
-        const taskId = taskIds[i];
-        try {
-            console.info(`Updating custom type/status on task ${taskId}`);
-            await client.tasks.updateTask({ data }, taskId, {});
-        } catch (error) {
-            console.error(`Error updating custom type/status on task ${taskId}:`, JSON.stringify(error));
-            const remaining = taskIds.slice(i + 1);
-            const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
-            core.setFailed(`Error updating custom type/status on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
-            return;
-        }
+    try {
+        console.info(`Updating custom type/status on task ${taskId}`);
+        await client.tasks.updateTask({ data }, taskId, {});
+    } catch (error) {
+        console.error(`Error updating custom type/status on task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Error updating custom type/status on task ${taskId}: ${formatErrorMessage(error)}`);
     }
 }
 

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
         description: 'Asana custom task type GID to apply to existing task(s)'
         required: false
     asana-task-custom-type-status-option:
-        description: 'Asana custom task type status option GID to apply to existing task(s)'
+        description: 'Asana custom task type status option GID to apply to an existing task'
         required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,12 @@ inputs:
     asana-task-custom-fields:
         description: 'Asana task custom fields hash, encoded as a JSON string'
         required: false
+    asana-task-custom-type:
+        description: 'Asana custom task type GID to apply to existing task(s)'
+        required: false
+    asana-task-custom-type-status-option:
+        description: 'Asana custom task type status option GID to apply to existing task(s)'
+        required: false
 
 runs:
     using: 'node24'

--- a/dist/index.js
+++ b/dist/index.js
@@ -301,6 +301,45 @@ async function updateTaskCustomFields(client, taskId, customFields) {
     await client.tasks.updateTask({ data: { custom_fields: customFields } }, taskId, {});
 }
 
+async function updateAsanaTaskTypeStatusAction() {
+    const client = buildAsanaClient();
+    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const customType = core.getInput('asana-task-custom-type');
+    const customTypeStatusOption = core.getInput('asana-task-custom-type-status-option');
+
+    if (taskIds.length === 0) {
+        core.setFailed('No valid task IDs provided');
+        return;
+    }
+
+    if (!customType && !customTypeStatusOption) {
+        core.setFailed('At least one of asana-task-custom-type or asana-task-custom-type-status-option is required');
+        return;
+    }
+
+    const data = customType
+        ? {
+              resource_subtype: 'custom',
+              custom_type: customType,
+              ...(customTypeStatusOption && { custom_type_status_option: customTypeStatusOption }),
+          }
+        : { custom_type_status_option: customTypeStatusOption };
+
+    for (let i = 0; i < taskIds.length; i++) {
+        const taskId = taskIds[i];
+        try {
+            console.info(`Updating custom type/status on task ${taskId}`);
+            await client.tasks.updateTask({ data }, taskId, {});
+        } catch (error) {
+            console.error(`Error updating custom type/status on task ${taskId}:`, JSON.stringify(error));
+            const remaining = taskIds.slice(i + 1);
+            const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
+            core.setFailed(`Error updating custom type/status on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
+            return;
+        }
+    }
+}
+
 async function addTaskToProject(client, taskId, projectId, sectionId) {
     if (!sectionId) {
         console.info('adding asana task to project', projectId);
@@ -939,6 +978,10 @@ async function action() {
         }
         case 'update-task-custom-fields': {
             await updateTaskCustomFieldsAction();
+            break;
+        }
+        case 'update-asana-task-type-status': {
+            await updateAsanaTaskTypeStatusAction();
             break;
         }
         default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -303,17 +303,17 @@ async function updateTaskCustomFields(client, taskId, customFields) {
 
 async function updateAsanaTaskTypeStatusAction() {
     const client = buildAsanaClient();
-    const taskIds = getArrayFromInput(core.getInput('asana-task-id', { required: true }));
+    const taskId = core.getInput('asana-task-id', { required: true }).trim();
     const customType = core.getInput('asana-task-custom-type');
     const customTypeStatusOption = core.getInput('asana-task-custom-type-status-option');
 
-    if (taskIds.length === 0) {
-        core.setFailed('No valid task IDs provided');
+    if (!taskId) {
+        core.setFailed('No valid task ID provided');
         return;
     }
 
-    if (!customType && !customTypeStatusOption) {
-        core.setFailed('At least one of asana-task-custom-type or asana-task-custom-type-status-option is required');
+    if (!customTypeStatusOption) {
+        core.setFailed('asana-task-custom-type-status-option is required');
         return;
     }
 
@@ -321,22 +321,16 @@ async function updateAsanaTaskTypeStatusAction() {
         ? {
               resource_subtype: 'custom',
               custom_type: customType,
-              ...(customTypeStatusOption && { custom_type_status_option: customTypeStatusOption }),
+              custom_type_status_option: customTypeStatusOption,
           }
         : { custom_type_status_option: customTypeStatusOption };
 
-    for (let i = 0; i < taskIds.length; i++) {
-        const taskId = taskIds[i];
-        try {
-            console.info(`Updating custom type/status on task ${taskId}`);
-            await client.tasks.updateTask({ data }, taskId, {});
-        } catch (error) {
-            console.error(`Error updating custom type/status on task ${taskId}:`, JSON.stringify(error));
-            const remaining = taskIds.slice(i + 1);
-            const suffix = remaining.length ? ` Skipped remaining tasks: ${remaining.join(', ')}.` : '';
-            core.setFailed(`Error updating custom type/status on task ${taskId}: ${formatErrorMessage(error)}.${suffix}`);
-            return;
-        }
+    try {
+        console.info(`Updating custom type/status on task ${taskId}`);
+        await client.tasks.updateTask({ data }, taskId, {});
+    } catch (error) {
+        console.error(`Error updating custom type/status on task ${taskId}:`, JSON.stringify(error));
+        core.setFailed(`Error updating custom type/status on task ${taskId}: ${formatErrorMessage(error)}`);
     }
 }
 

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -766,6 +766,96 @@ describe('GitHub Asana Sync Action', () => {
         });
     });
 
+    describe('action: update-asana-task-type-status', () => {
+        it('should set a custom type and status in one exact request', async () => {
+            mockGetInput({
+                action: 'update-asana-task-type-status',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': 'task-abc',
+                'asana-task-custom-type': 'type-gid',
+                'asana-task-custom-type-status-option': 'status-gid',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
+                {
+                    data: {
+                        resource_subtype: 'custom',
+                        custom_type: 'type-gid',
+                        custom_type_status_option: 'status-gid',
+                    },
+                },
+                'task-abc',
+                {},
+            );
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should set only the status when no custom type is provided', async () => {
+            mockGetInput({
+                action: 'update-asana-task-type-status',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': 'task-abc',
+                'asana-task-custom-type-status-option': 'status-gid',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledWith(
+                { data: { custom_type_status_option: 'status-gid' } },
+                'task-abc',
+                {},
+            );
+            expect(core.setFailed).not.toHaveBeenCalled();
+        });
+
+        it('should fail when task IDs or update fields are missing', async () => {
+            mockGetInput({
+                action: 'update-asana-task-type-status',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': ',',
+                'asana-task-custom-type-status-option': 'status-gid',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith('No valid task IDs provided');
+
+            core.setFailed.mockClear();
+            mockGetInput({
+                action: 'update-asana-task-type-status',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': 'task-abc',
+            });
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
+            expect(core.setFailed).toHaveBeenCalledWith(
+                'At least one of asana-task-custom-type or asana-task-custom-type-status-option is required',
+            );
+        });
+
+        it('should stop after the first API rejection', async () => {
+            mockGetInput({
+                action: 'update-asana-task-type-status',
+                'asana-pat': 'mock-asana-pat',
+                'asana-task-id': 'task-abc, task-def',
+                'asana-task-custom-type-status-option': 'status-gid',
+            });
+            mockAsanaClient.tasks.updateTask.mockRejectedValueOnce(new Error('boom'));
+
+            await action();
+
+            expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
+            expect(core.setFailed).toHaveBeenCalledWith(
+                'Error updating custom type/status on task task-abc: boom. Skipped remaining tasks: task-def.',
+            );
+        });
+    });
+
     describe('action: create-asana-pr-task', () => {
         it('should create an Asana task from a GitHub PR', async () => {
             mockGetInput({

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -810,18 +810,18 @@ describe('GitHub Asana Sync Action', () => {
             expect(core.setFailed).not.toHaveBeenCalled();
         });
 
-        it('should fail when task IDs or update fields are missing', async () => {
+        it('should fail when the task ID or status is missing', async () => {
             mockGetInput({
                 action: 'update-asana-task-type-status',
                 'asana-pat': 'mock-asana-pat',
-                'asana-task-id': ',',
+                'asana-task-id': ' ',
                 'asana-task-custom-type-status-option': 'status-gid',
             });
 
             await action();
 
             expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
-            expect(core.setFailed).toHaveBeenCalledWith('No valid task IDs provided');
+            expect(core.setFailed).toHaveBeenCalledWith('No valid task ID provided');
 
             core.setFailed.mockClear();
             mockGetInput({
@@ -833,16 +833,14 @@ describe('GitHub Asana Sync Action', () => {
             await action();
 
             expect(mockAsanaClient.tasks.updateTask).not.toHaveBeenCalled();
-            expect(core.setFailed).toHaveBeenCalledWith(
-                'At least one of asana-task-custom-type or asana-task-custom-type-status-option is required',
-            );
+            expect(core.setFailed).toHaveBeenCalledWith('asana-task-custom-type-status-option is required');
         });
 
-        it('should stop after the first API rejection', async () => {
+        it('should report an API rejection', async () => {
             mockGetInput({
                 action: 'update-asana-task-type-status',
                 'asana-pat': 'mock-asana-pat',
-                'asana-task-id': 'task-abc, task-def',
+                'asana-task-id': 'task-abc',
                 'asana-task-custom-type-status-option': 'status-gid',
             });
             mockAsanaClient.tasks.updateTask.mockRejectedValueOnce(new Error('boom'));
@@ -850,9 +848,7 @@ describe('GitHub Asana Sync Action', () => {
             await action();
 
             expect(mockAsanaClient.tasks.updateTask).toHaveBeenCalledTimes(1);
-            expect(core.setFailed).toHaveBeenCalledWith(
-                'Error updating custom type/status on task task-abc: boom. Skipped remaining tasks: task-def.',
-            );
+            expect(core.setFailed).toHaveBeenCalledWith('Error updating custom type/status on task task-abc: boom');
         });
     });
 


### PR DESCRIPTION
For: https://app.asana.com/1/137249556945/project/1171671347221384/task/1217621822527831?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and Asana task metadata; failures could block privacy triage automation but do not touch product auth or data paths.
> 
> **Overview**
> Adds a new **`update-asana-task-type-status`** action so workflows can set an Asana custom task type and/or type status on an existing task via `tasks.updateTask` (optional type GID plus required status option GID).
> 
> The **Start Privacy Review** composite action now uses it right after task creation to apply the privacy triage custom type and **In progress**, then after dispatching the AI classifier it moves the task to **Waiting for AI review**. The classifier workflow dispatch also receives **`team_name`** alongside the PR URL and triage task ID.
> 
> README documents the action; **`action.test.js`** covers type+status, status-only, validation, and API errors. **`dist/index.js`** mirrors **`action.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbb53fa30a2a06ab6533accfce75b43c03f9c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->